### PR TITLE
Generate steps from stepdefs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+- Generate suggestions for Cucumber Expressions even if there are no matching steps. ([#16](https://github.com/cucumber/language-service/issues/16), [#32](https://github.com/cucumber/language-service/pull/32))
+
 ### Changed
 - The `ExpressionBuilder` constructor has changed. Consumers must provide a `ParserAdpater` - currently a `NodeParserAdapter` is the only implementation.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.12.1",
       "license": "MIT",
       "dependencies": {
-        "@cucumber/cucumber-expressions": "^15.0.2",
+        "@cucumber/cucumber-expressions": "^15.1.0",
         "@cucumber/gherkin": "^23.0.1",
         "@cucumber/gherkin-utils": "^7.0.0",
         "@cucumber/messages": "^18.0.0",
@@ -134,9 +134,18 @@
       }
     },
     "node_modules/@cucumber/cucumber-expressions": {
+      "version": "15.1.0",
+      "resolved": "https://registry.npmjs.org/@cucumber/cucumber-expressions/-/cucumber-expressions-15.1.0.tgz",
+      "integrity": "sha512-HLeRHR1h0v69t1eYXLhPz0qXNuIyMSLElqJvvi7WHF2J3ClBXFAPkAk0zhS03DHuoZi6v1TZLIpoZ+Wbehp5xw==",
+      "dependencies": {
+        "regexp-match-indices": "1.0.2"
+      }
+    },
+    "node_modules/@cucumber/cucumber/node_modules/@cucumber/cucumber-expressions": {
       "version": "15.0.2",
       "resolved": "https://registry.npmjs.org/@cucumber/cucumber-expressions/-/cucumber-expressions-15.0.2.tgz",
       "integrity": "sha512-ppN9JL1C5lw3InvM7WnoKZV9La5PW5Vr8c/8J0ZGzdlC8Y+PB7kskGzx7/tzl9kGjq7USQ7MZfwFz5el2sB/GA==",
+      "dev": true,
       "dependencies": {
         "regexp-match-indices": "1.0.2"
       }
@@ -7115,6 +7124,15 @@
         "yup": "^0.32.11"
       },
       "dependencies": {
+        "@cucumber/cucumber-expressions": {
+          "version": "15.0.2",
+          "resolved": "https://registry.npmjs.org/@cucumber/cucumber-expressions/-/cucumber-expressions-15.0.2.tgz",
+          "integrity": "sha512-ppN9JL1C5lw3InvM7WnoKZV9La5PW5Vr8c/8J0ZGzdlC8Y+PB7kskGzx7/tzl9kGjq7USQ7MZfwFz5el2sB/GA==",
+          "dev": true,
+          "requires": {
+            "regexp-match-indices": "1.0.2"
+          }
+        },
         "@cucumber/gherkin": {
           "version": "22.0.0",
           "resolved": "https://registry.npmjs.org/@cucumber/gherkin/-/gherkin-22.0.0.tgz",
@@ -7175,9 +7193,9 @@
       }
     },
     "@cucumber/cucumber-expressions": {
-      "version": "15.0.2",
-      "resolved": "https://registry.npmjs.org/@cucumber/cucumber-expressions/-/cucumber-expressions-15.0.2.tgz",
-      "integrity": "sha512-ppN9JL1C5lw3InvM7WnoKZV9La5PW5Vr8c/8J0ZGzdlC8Y+PB7kskGzx7/tzl9kGjq7USQ7MZfwFz5el2sB/GA==",
+      "version": "15.1.0",
+      "resolved": "https://registry.npmjs.org/@cucumber/cucumber-expressions/-/cucumber-expressions-15.1.0.tgz",
+      "integrity": "sha512-HLeRHR1h0v69t1eYXLhPz0qXNuIyMSLElqJvvi7WHF2J3ClBXFAPkAk0zhS03DHuoZi6v1TZLIpoZ+Wbehp5xw==",
       "requires": {
         "regexp-match-indices": "1.0.2"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.12.1",
       "license": "MIT",
       "dependencies": {
-        "@cucumber/cucumber-expressions": "^15.1.0",
+        "@cucumber/cucumber-expressions": "^15.1.1",
         "@cucumber/gherkin": "^23.0.1",
         "@cucumber/gherkin-utils": "^7.0.0",
         "@cucumber/messages": "^18.0.0",
@@ -134,9 +134,9 @@
       }
     },
     "node_modules/@cucumber/cucumber-expressions": {
-      "version": "15.1.0",
-      "resolved": "https://registry.npmjs.org/@cucumber/cucumber-expressions/-/cucumber-expressions-15.1.0.tgz",
-      "integrity": "sha512-HLeRHR1h0v69t1eYXLhPz0qXNuIyMSLElqJvvi7WHF2J3ClBXFAPkAk0zhS03DHuoZi6v1TZLIpoZ+Wbehp5xw==",
+      "version": "15.1.1",
+      "resolved": "https://registry.npmjs.org/@cucumber/cucumber-expressions/-/cucumber-expressions-15.1.1.tgz",
+      "integrity": "sha512-+LtEEMJpnbppkZO3VZttgPV6Dcocmwy4oF4bDARZchcRV+hqQYZi7T1jp8cDO6EDng0EMzFNGiveAOh/eAO83A==",
       "dependencies": {
         "regexp-match-indices": "1.0.2"
       }
@@ -7193,9 +7193,9 @@
       }
     },
     "@cucumber/cucumber-expressions": {
-      "version": "15.1.0",
-      "resolved": "https://registry.npmjs.org/@cucumber/cucumber-expressions/-/cucumber-expressions-15.1.0.tgz",
-      "integrity": "sha512-HLeRHR1h0v69t1eYXLhPz0qXNuIyMSLElqJvvi7WHF2J3ClBXFAPkAk0zhS03DHuoZi6v1TZLIpoZ+Wbehp5xw==",
+      "version": "15.1.1",
+      "resolved": "https://registry.npmjs.org/@cucumber/cucumber-expressions/-/cucumber-expressions-15.1.1.tgz",
+      "integrity": "sha512-+LtEEMJpnbppkZO3VZttgPV6Dcocmwy4oF4bDARZchcRV+hqQYZi7T1jp8cDO6EDng0EMzFNGiveAOh/eAO83A==",
       "requires": {
         "regexp-match-indices": "1.0.2"
       }

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "typescript": "4.6.3"
   },
   "dependencies": {
-    "@cucumber/cucumber-expressions": "^15.1.0",
+    "@cucumber/cucumber-expressions": "^15.1.1",
     "@cucumber/gherkin": "^23.0.1",
     "@cucumber/gherkin-utils": "^7.0.0",
     "@cucumber/messages": "^18.0.0",

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "typescript": "4.6.3"
   },
   "dependencies": {
-    "@cucumber/cucumber-expressions": "^15.0.2",
+    "@cucumber/cucumber-expressions": "^15.1.0",
     "@cucumber/gherkin": "^23.0.1",
     "@cucumber/gherkin-utils": "^7.0.0",
     "@cucumber/messages": "^18.0.0",

--- a/src/messages/MessagesBuilder.ts
+++ b/src/messages/MessagesBuilder.ts
@@ -16,7 +16,7 @@ export type MessagesBuilderResult = {
 }
 
 /**
- * Builds CucumberInfo from Cucumber Messages.
+ * Builds MessagesBuilderResult from Cucumber Messages.
  */
 export class MessagesBuilder {
   private readonly parameterTypeRegistry = new ParameterTypeRegistry()
@@ -65,7 +65,11 @@ export class MessagesBuilder {
 
   build(): MessagesBuilderResult {
     return {
-      stepDocuments: buildStepDocuments(this.stepTexts, this.expressions),
+      stepDocuments: buildStepDocuments(
+        this.parameterTypeRegistry,
+        this.stepTexts,
+        this.expressions
+      ),
       expressions: this.expressions,
     }
   }

--- a/src/step-documents/buildStepDocumentFromCucumberExpression.ts
+++ b/src/step-documents/buildStepDocumentFromCucumberExpression.ts
@@ -99,7 +99,7 @@ function compileParameter(
   const parameterType = registry.lookupByTypeName(node.text())
   if (parameterType === undefined) throw new Error(`No parameter type named ${node.text()}`)
   const key = makeKey(parameterType)
-  return parameterChoices[key] || ['']
+  return parameterChoices[key] || defaultParameterChoices(parameterType) || ['']
 }
 
 function compileExpression(
@@ -112,4 +112,12 @@ function compileExpression(
 
 function makeKey(parameterType: ParameterType<unknown>): string {
   return parameterType.name || parameterType.regexpStrings.join('|')
+}
+
+function defaultParameterChoices(parameterType: ParameterType<unknown>): readonly string[] {
+  // @ts-ignore
+  if (parameterType.type === Number) {
+    return ['0']
+  }
+  return ['?']
 }

--- a/src/step-documents/buildStepDocumentFromCucumberExpression.ts
+++ b/src/step-documents/buildStepDocumentFromCucumberExpression.ts
@@ -1,0 +1,88 @@
+import {
+  CucumberExpression,
+  Node,
+  NodeType,
+  ParameterTypeRegistry,
+} from '@cucumber/cucumber-expressions'
+
+import { StepDocument, StepSegments } from './types'
+
+export function buildStepDocumentFromCucumberExpression(
+  expression: CucumberExpression,
+  registry: ParameterTypeRegistry
+): StepDocument {
+  // @ts-ignore
+  const ast: Node = expression.ast
+  const compiledSegments = compile(ast, registry)
+  const segments = flatten(compiledSegments)
+  return {
+    suggestion: expression.source,
+    segments,
+  }
+}
+
+type CompileResult = string | CompileResult[]
+
+function flatten(cr: CompileResult): StepSegments {
+  if (typeof cr === 'string') return [cr]
+  return cr.reduce<StepSegments>((prev, curr) => {
+    const last = prev[prev.length - 1]
+    if (typeof curr === 'string') {
+      if (typeof last === 'string') {
+        return prev.slice(0, prev.length - 1).concat([last + curr])
+      } else {
+        return prev.concat(curr)
+      }
+    } else {
+      const x = curr.flatMap((e) => {
+        if (typeof e === 'string') return e
+        const e0 = e[0]
+        if (Array.isArray(e0)) throw new Error('Unexpected array: ' + JSON.stringify(e))
+        return e0
+      })
+      return prev.concat([x])
+    }
+  }, [])
+}
+
+function compile(node: Node, registry: ParameterTypeRegistry): CompileResult {
+  switch (node.type) {
+    case NodeType.text:
+      return node.text()
+    case NodeType.optional:
+      return compileOptional(node, registry)
+    case NodeType.alternation:
+      return compileAlternation(node, registry)
+    case NodeType.alternative:
+      return compileAlternative(node, registry)
+    case NodeType.parameter:
+      return compileParameter(node, registry)
+    case NodeType.expression:
+      return compileExpression(node, registry)
+    default:
+      // Can't happen as long as the switch case is exhaustive
+      throw new Error(node.type)
+  }
+}
+
+function compileOptional(node: Node, registry: ParameterTypeRegistry): CompileResult {
+  if (node.nodes === undefined) throw new Error('No optional')
+  return [node.nodes[0].text(), '']
+}
+
+function compileAlternation(node: Node, registry: ParameterTypeRegistry): CompileResult {
+  return (node.nodes || []).map((node) => compile(node, registry))
+}
+
+function compileAlternative(node: Node, registry: ParameterTypeRegistry): CompileResult {
+  return (node.nodes || []).map((node) => compile(node, registry))
+}
+
+function compileParameter(node: Node, registry: ParameterTypeRegistry): CompileResult {
+  const parameterType = registry.lookupByTypeName(node.text())
+  throw new Error('Method not implemented.')
+}
+
+function compileExpression(node: Node, registry: ParameterTypeRegistry): CompileResult {
+  return (node.nodes || []).map((node) => compile(node, registry))
+}

--- a/src/step-documents/buildStepDocumentFromCucumberExpression.ts
+++ b/src/step-documents/buildStepDocumentFromCucumberExpression.ts
@@ -6,7 +6,7 @@ import {
   ParameterTypeRegistry,
 } from '@cucumber/cucumber-expressions'
 
-import { StepDocument, StepSegments } from './types'
+import { ParameterChoices, StepDocument, StepSegments } from './types'
 
 export function buildStepDocumentFromCucumberExpression(
   expression: CucumberExpression,
@@ -22,7 +22,6 @@ export function buildStepDocumentFromCucumberExpression(
 }
 
 type CompileResult = string | readonly CompileResult[]
-type ParameterChoices = Record<string, readonly string[]>
 
 function flatten(cr: CompileResult): StepSegments {
   if (typeof cr === 'string') return [cr]

--- a/src/step-documents/buildStepDocumentFromCucumberExpression.ts
+++ b/src/step-documents/buildStepDocumentFromCucumberExpression.ts
@@ -6,7 +6,8 @@ import {
   ParameterTypeRegistry,
 } from '@cucumber/cucumber-expressions'
 
-import { ParameterChoices, StepDocument, StepSegments } from './types'
+import { makeKey } from './helpers.js'
+import { ParameterChoices, StepDocument, StepSegments } from './types.js'
 
 export function buildStepDocumentFromCucumberExpression(
   expression: CucumberExpression,
@@ -107,10 +108,6 @@ function compileExpression(
   parameterChoices: ParameterChoices
 ): CompileResult {
   return (node.nodes || []).map((node) => compile(node, registry, parameterChoices))
-}
-
-function makeKey(parameterType: ParameterType<unknown>): string {
-  return parameterType.name || parameterType.regexpStrings.join('|')
 }
 
 function defaultParameterChoices(parameterType: ParameterType<unknown>): readonly string[] {

--- a/src/step-documents/buildStepDocuments.ts
+++ b/src/step-documents/buildStepDocuments.ts
@@ -1,4 +1,10 @@
-import { Expression } from '@cucumber/cucumber-expressions'
+import {
+  AbstractCompiler,
+  CucumberExpression,
+  Expression,
+  ParameterType,
+  ParameterTypeRegistry,
+} from '@cucumber/cucumber-expressions'
 
 import { StepDocument } from './types.js'
 
@@ -9,11 +15,13 @@ type ParameterTypeData = { name: string; regexpStrings: string }
 /**
  * Builds an array of {@link StepDocument} from steps and step definitions.
  *
+ * @param parameterTypeRegistry
  * @param stepTexts
  * @param expressions
  * @param maxChoices
  */
 export function buildStepDocuments(
+  parameterTypeRegistry: ParameterTypeRegistry,
   stepTexts: readonly string[],
   expressions: readonly Expression[],
   maxChoices = 10
@@ -21,11 +29,14 @@ export function buildStepDocuments(
   const jsonTextOrParameterTypeNameExpression = new Set<string>()
   const choicesByParameterTypeRegexpStrings = new Map<string, Set<string>>()
   const expressionByJson = new Map<string, Expression>()
+  const suggestionByJson = new Map<string, string>()
 
   for (const expression of expressions) {
+    let matched = false
     for (const text of stepTexts) {
       const args = expression.match(text)
       if (args) {
+        matched = true
         const parameterTypes = args.map((arg) => arg.getParameterType())
         const textOrParameterTypeNameExpression: TextOrParameterTypeNameExpression = []
         let index = 0
@@ -50,10 +61,29 @@ export function buildStepDocuments(
         if (lastSegment !== '') {
           textOrParameterTypeNameExpression.push(lastSegment)
         }
+
         const json = JSON.stringify(textOrParameterTypeNameExpression)
         expressionByJson.set(json, expression)
+        const suggestion = textOrParameterTypeNameExpression
+          .map((segment) => {
+            if (typeof segment === 'string') {
+              return segment
+            } else {
+              return `{${segment.name}}`
+            }
+          })
+          .join('')
+        suggestionByJson.set(json, suggestion)
         jsonTextOrParameterTypeNameExpression.add(json)
       }
+    }
+    if (!matched && expression instanceof CucumberExpression) {
+      const compiler = new SegmentCompiler(expression.source, parameterTypeRegistry)
+      const textOrParameterTypeNameExpression = compiler.compile(expression.ast)
+      const json = JSON.stringify(textOrParameterTypeNameExpression)
+      expressionByJson.set(json, expression)
+      suggestionByJson.set(json, expression.source)
+      jsonTextOrParameterTypeNameExpression.add(json)
     }
   }
 
@@ -62,15 +92,8 @@ export function buildStepDocuments(
     const expression = expressionByJson.get(json)
     if (!expression) throw new Error(`No expression for json key ${json}`)
 
-    const suggestion = textOrParameterTypeNameExpression
-      .map((segment) => {
-        if (typeof segment === 'string') {
-          return segment
-        } else {
-          return `{${segment.name}}`
-        }
-      })
-      .join('')
+    const suggestion = suggestionByJson.get(json)
+    if (!suggestion) throw new Error(`No suggestion for json key ${json}`)
 
     const segments = textOrParameterTypeNameExpression.map((segment) => {
       if (typeof segment === 'string') {
@@ -89,4 +112,50 @@ export function buildStepDocuments(
 
     return stepDocument
   })
+}
+
+class SegmentCompiler extends AbstractCompiler<TextOrParameterTypeNameExpression> {
+  protected produceText(expression: string) {
+    return [expression]
+  }
+
+  protected produceOptional(
+    segments: TextOrParameterTypeNameExpression[]
+  ): TextOrParameterTypeNameExpression {
+    throw new Error('Method not implemented.')
+  }
+
+  protected produceAlternative(
+    segments: TextOrParameterTypeNameExpression[]
+  ): TextOrParameterTypeNameExpression {
+    throw new Error('Method not implemented.')
+  }
+
+  protected produceAlternation(
+    segments: TextOrParameterTypeNameExpression[]
+  ): TextOrParameterTypeNameExpression {
+    throw new Error('Method not implemented.')
+  }
+
+  protected produceParameter(
+    parameterType: ParameterType<unknown>
+  ): TextOrParameterTypeNameExpression {
+    const name = parameterType.name || '?'
+    const regexpStrings = parameterType.regexpStrings.join('|')
+    const parameterTypeData: ParameterTypeData = { name, regexpStrings }
+    return [parameterTypeData]
+  }
+
+  protected produceExpression(
+    segments: TextOrParameterTypeNameExpression[]
+  ): TextOrParameterTypeNameExpression {
+    return segments.reduce((prev, curr) => {
+      const last = prev[prev.length - 1]
+      if (typeof last === 'string' && typeof curr[0] === 'string') {
+        return prev.slice(0, prev.length - 1).concat([last + curr[0]])
+      } else {
+        return prev.concat(curr)
+      }
+    }, [])
+  }
 }

--- a/src/step-documents/buildStepDocumentsFromRegularExpression.ts
+++ b/src/step-documents/buildStepDocumentsFromRegularExpression.ts
@@ -1,0 +1,43 @@
+import { ParameterTypeRegistry, RegularExpression } from '@cucumber/cucumber-expressions'
+
+import { ParameterChoices, StepDocument, StepSegment } from './types'
+
+export function buildStepDocumentsFromRegularExpression(
+  expression: RegularExpression,
+  registry: ParameterTypeRegistry,
+  stepTexts: readonly string[],
+  parameterChoices: ParameterChoices
+): StepDocument[] {
+  const stepDocuments: StepDocument[] = []
+  for (const text of stepTexts) {
+    const args = expression.match(text)
+    if (args) {
+      const parameterTypes = args.map((arg) => arg.getParameterType())
+      const segments: StepSegment[] = []
+      let index = 0
+      for (let argIndex = 0; argIndex < args.length; argIndex++) {
+        const arg = args[argIndex]
+
+        const textSegment = text.substring(index, arg.group.start)
+        segments.push(textSegment)
+        const parameterType = parameterTypes[argIndex]
+
+        const key = parameterType.regexpStrings.join('|')
+        const parameterSegment = parameterChoices[key]
+        segments.push(parameterSegment)
+
+        if (arg.group.end !== undefined) index = arg.group.end
+      }
+      const lastSegment = text.substring(index)
+      if (lastSegment !== '') {
+        segments.push(lastSegment)
+      }
+
+      stepDocuments.push({
+        suggestion: expression.source,
+        segments,
+      })
+    }
+  }
+  return stepDocuments
+}

--- a/src/step-documents/buildStepDocumentsFromRegularExpression.ts
+++ b/src/step-documents/buildStepDocumentsFromRegularExpression.ts
@@ -8,7 +8,8 @@ export function buildStepDocumentsFromRegularExpression(
   stepTexts: readonly string[],
   parameterChoices: ParameterChoices
 ): StepDocument[] {
-  const stepDocuments: StepDocument[] = []
+  const segmentJsons = new Set<string>()
+
   for (const text of stepTexts) {
     const args = expression.match(text)
     if (args) {
@@ -32,12 +33,11 @@ export function buildStepDocumentsFromRegularExpression(
       if (lastSegment !== '') {
         segments.push(lastSegment)
       }
-
-      stepDocuments.push({
-        suggestion: expression.source,
-        segments,
-      })
+      segmentJsons.add(JSON.stringify(segments))
     }
   }
-  return stepDocuments
+  return [...segmentJsons].sort().map((s, n) => ({
+    segments: JSON.parse(s) as StepSegment[],
+    suggestion: n == 0 ? expression.source : `${expression.source} (${n + 1})`,
+  }))
 }

--- a/src/step-documents/helpers.ts
+++ b/src/step-documents/helpers.ts
@@ -1,0 +1,5 @@
+import { ParameterType } from '@cucumber/cucumber-expressions'
+
+export function makeKey(parameterType: ParameterType<unknown>): string {
+  return parameterType.name || parameterType.regexpStrings.join('|')
+}

--- a/src/step-documents/types.ts
+++ b/src/step-documents/types.ts
@@ -1,6 +1,10 @@
 import { Expression } from '@cucumber/cucumber-expressions'
 
 /**
+ * TODO: Rename to AutoCompleteItem
+ * A StepDocument is a data structure for auto-completion.
+ *
+ * TODO: Remove/reformulate
  * A document that can be indexed. It's recommended to index the segments rather than the suggestion.
  * When indexing the segments, the nested arrays (representing choices) may be given lower weight
  * than the string segments (which represent the "sentence")
@@ -23,7 +27,7 @@ export type StepDocument = {
   /**
    * The Cucumber Expression or Regular Expression
    */
-  expression: Expression
+  expression?: Expression
 }
 
 export type StepSegments = readonly StepSegment[]

--- a/src/step-documents/types.ts
+++ b/src/step-documents/types.ts
@@ -27,7 +27,7 @@ export type StepDocument = {
   /**
    * The Cucumber Expression or Regular Expression
    */
-  expression?: Expression
+  // expression: Expression
 }
 
 export type StepSegments = readonly StepSegment[]

--- a/src/step-documents/types.ts
+++ b/src/step-documents/types.ts
@@ -34,3 +34,5 @@ export type StepSegments = readonly StepSegment[]
 type Text = string
 type Choices = readonly string[]
 export type StepSegment = Text | Choices
+
+export type ParameterChoices = Record<string, readonly string[]>

--- a/src/step-documents/types.ts
+++ b/src/step-documents/types.ts
@@ -1,10 +1,8 @@
-import { Expression } from '@cucumber/cucumber-expressions'
-
 /**
  * TODO: Rename to AutoCompleteItem
  * A StepDocument is a data structure for auto-completion.
  *
- * TODO: Remove/reformulate
+ * TODO: Move this comment to the index
  * A document that can be indexed. It's recommended to index the segments rather than the suggestion.
  * When indexing the segments, the nested arrays (representing choices) may be given lower weight
  * than the string segments (which represent the "sentence")

--- a/test/index/Index.test.ts
+++ b/test/index/Index.test.ts
@@ -10,17 +10,13 @@ type BuildIndex = (stepDocuments: readonly StepDocument[]) => Index
 function verifyIndexContract(name: string, buildIndex: BuildIndex) {
   describe(name, () => {
     describe('basics', () => {
-      const ef = new ExpressionFactory(new ParameterTypeRegistry())
-
       const doc1: StepDocument = {
         suggestion: 'I have {int} cukes in my belly',
         segments: ['I have ', ['42', '98'], ' cukes in my belly'],
-        expression: ef.createExpression('I have {int} cukes in my belly'),
       }
       const doc2: StepDocument = {
         suggestion: 'I am a teapot',
         segments: ['I am a teapot'],
-        expression: ef.createExpression('I am a teapot'),
       }
       let index: Index
       beforeEach(() => {

--- a/test/messages/MessagesBuilder.test.ts
+++ b/test/messages/MessagesBuilder.test.ts
@@ -63,7 +63,7 @@ describe('MessagesBuilder', () => {
         },
       })
     )
-    const expectedStepDocuments: Partial<StepDocument>[] = [
+    const expectedStepDocuments: StepDocument[] = [
       {
         segments: ['I select the ', ['2nd'], ' snippet'],
         suggestion: 'I select the {ordinal} snippet',
@@ -76,19 +76,19 @@ describe('MessagesBuilder', () => {
         suggestion: 'I type {string}',
       },
       {
-        segments: [
-          'the LSP snippet should be ',
-          ['"I have ${1|11,17,23|} cukes on my ${2|belly,table,tree|}"', '"cukes"'],
-        ],
-        suggestion: 'the LSP snippet should be {string}',
-      },
-      {
         segments: ['the following Gherkin step texts exist:'],
         suggestion: 'the following Gherkin step texts exist:',
       },
       {
         segments: ['the following Step Definitions exist:'],
         suggestion: 'the following Step Definitions exist:',
+      },
+      {
+        segments: [
+          'the LSP snippet should be ',
+          ['"I have ${1|11,17,23|} cukes on my ${2|belly,table,tree|}"', '"cukes"'],
+        ],
+        suggestion: 'the LSP snippet should be {string}',
       },
       {
         segments: ['the suggestions should be empty'],

--- a/test/service/getGherkinCompletionItems.test.ts
+++ b/test/service/getGherkinCompletionItems.test.ts
@@ -1,4 +1,3 @@
-import { ExpressionFactory, ParameterTypeRegistry } from '@cucumber/cucumber-expressions'
 import assert from 'assert'
 import { CompletionItem, CompletionItemKind, InsertTextFormat } from 'vscode-languageserver-types'
 
@@ -8,16 +7,13 @@ import { StepDocument } from '../../src/step-documents/types.js'
 
 describe('getGherkinCompletionItems', () => {
   it('completes with step text', () => {
-    const ef = new ExpressionFactory(new ParameterTypeRegistry())
     const doc1: StepDocument = {
       suggestion: 'I have {int} cukes in my belly',
       segments: ['I have ', ['42', '98'], ' cukes in my belly'],
-      expression: ef.createExpression('I have {int} cukes in my belly'),
     }
     const doc2: StepDocument = {
       suggestion: 'I am a teapot',
       segments: ['I am a teapot'],
-      expression: ef.createExpression('I am a teapot'),
     }
 
     const index = bruteForceIndex([doc1, doc2])

--- a/test/step-documents/buildStepDocumentFromCucumberExpression.test.ts
+++ b/test/step-documents/buildStepDocumentFromCucumberExpression.test.ts
@@ -20,7 +20,7 @@ describe('buildStepDocumentFromCucumberExpression', () => {
     assert.deepStrictEqual(actual, expected)
   })
 
-  it('builds an item from alternate expression', () => {
+  it('builds an item from alternation expression', () => {
     const expression = new CucumberExpression('I have 4/5 cukes', registry)
     const expected: StepDocument = {
       segments: ['I have ', ['4', '5'], ' cukes'],
@@ -40,7 +40,7 @@ describe('buildStepDocumentFromCucumberExpression', () => {
     assert.deepStrictEqual(actual, expected)
   })
 
-  it('builds an item from parameter expression', () => {
+  it('builds an item from parameter expression with explicit options', () => {
     const expression = new CucumberExpression('I have {int} cukes', registry)
     const expected: StepDocument = {
       segments: ['I have ', ['12', '17'], ' cukes'],
@@ -48,6 +48,38 @@ describe('buildStepDocumentFromCucumberExpression', () => {
     }
     const actual = buildStepDocumentFromCucumberExpression(expression, registry, {
       int: ['12', '17'],
+    })
+    assert.deepStrictEqual(actual, expected)
+  })
+
+  it('builds an item from int parameter expression without explicit options', () => {
+    const expression = new CucumberExpression('I have {int} cukes', registry)
+    const expected: StepDocument = {
+      segments: ['I have ', ['0'], ' cukes'],
+      suggestion: 'I have {int} cukes',
+    }
+    const actual = buildStepDocumentFromCucumberExpression(expression, registry, {})
+    assert.deepStrictEqual(actual, expected)
+  })
+
+  it('builds an item from only alternation expression', () => {
+    const expression = new CucumberExpression('me/you', registry)
+    const expected: StepDocument = {
+      segments: [['me', 'you']],
+      suggestion: 'me/you',
+    }
+    const actual = buildStepDocumentFromCucumberExpression(expression, registry, {})
+    assert.deepStrictEqual(actual, expected)
+  })
+
+  it('builds an item from complex expression', () => {
+    const expression = new CucumberExpression('I have {int} cuke(s) in my bag/belly', registry)
+    const expected: StepDocument = {
+      segments: ['I have ', ['12'], ' cuke', ['s', ''], ' in my ', ['bag', 'belly']],
+      suggestion: 'I have {int} cuke(s) in my bag/belly',
+    }
+    const actual = buildStepDocumentFromCucumberExpression(expression, registry, {
+      int: ['12'],
     })
     assert.deepStrictEqual(actual, expected)
   })

--- a/test/step-documents/buildStepDocumentFromCucumberExpression.test.ts
+++ b/test/step-documents/buildStepDocumentFromCucumberExpression.test.ts
@@ -1,0 +1,42 @@
+import { CucumberExpression, ParameterTypeRegistry } from '@cucumber/cucumber-expressions'
+import assert from 'assert'
+
+import { buildStepDocumentFromCucumberExpression } from '../../src/step-documents/buildStepDocumentFromCucumberExpression.js'
+import { StepDocument } from '../../src/step-documents/types.js'
+
+describe('buildStepDocumentFromCucumberExpression', () => {
+  let registry: ParameterTypeRegistry
+  beforeEach(() => {
+    registry = new ParameterTypeRegistry()
+  })
+
+  it('builds an item from plain expression', () => {
+    const expression = new CucumberExpression('I have 4 cukes', registry)
+    const expected: StepDocument = {
+      segments: ['I have 4 cukes'],
+      suggestion: 'I have 4 cukes',
+    }
+    const actual = buildStepDocumentFromCucumberExpression(expression, registry)
+    assert.deepStrictEqual(actual, expected)
+  })
+
+  it('builds an item from alternate expression', () => {
+    const expression = new CucumberExpression('I have 4/5 cukes', registry)
+    const expected: StepDocument = {
+      segments: ['I have ', ['4', '5'], ' cukes'],
+      suggestion: 'I have 4/5 cukes',
+    }
+    const actual = buildStepDocumentFromCucumberExpression(expression, registry)
+    assert.deepStrictEqual(actual, expected)
+  })
+
+  it('builds an item from optional expression', () => {
+    const expression = new CucumberExpression('I have 1 cuke(s)', registry)
+    const expected: StepDocument = {
+      segments: ['I have 1 cuke', ['s', '']],
+      suggestion: 'I have 1 cuke(s)',
+    }
+    const actual = buildStepDocumentFromCucumberExpression(expression, registry)
+    assert.deepStrictEqual(actual, expected)
+  })
+})

--- a/test/step-documents/buildStepDocumentFromCucumberExpression.test.ts
+++ b/test/step-documents/buildStepDocumentFromCucumberExpression.test.ts
@@ -16,7 +16,7 @@ describe('buildStepDocumentFromCucumberExpression', () => {
       segments: ['I have 4 cukes'],
       suggestion: 'I have 4 cukes',
     }
-    const actual = buildStepDocumentFromCucumberExpression(expression, registry)
+    const actual = buildStepDocumentFromCucumberExpression(expression, registry, {})
     assert.deepStrictEqual(actual, expected)
   })
 
@@ -26,7 +26,7 @@ describe('buildStepDocumentFromCucumberExpression', () => {
       segments: ['I have ', ['4', '5'], ' cukes'],
       suggestion: 'I have 4/5 cukes',
     }
-    const actual = buildStepDocumentFromCucumberExpression(expression, registry)
+    const actual = buildStepDocumentFromCucumberExpression(expression, registry, {})
     assert.deepStrictEqual(actual, expected)
   })
 
@@ -36,7 +36,19 @@ describe('buildStepDocumentFromCucumberExpression', () => {
       segments: ['I have 1 cuke', ['s', '']],
       suggestion: 'I have 1 cuke(s)',
     }
-    const actual = buildStepDocumentFromCucumberExpression(expression, registry)
+    const actual = buildStepDocumentFromCucumberExpression(expression, registry, {})
+    assert.deepStrictEqual(actual, expected)
+  })
+
+  it('builds an item from parameter expression', () => {
+    const expression = new CucumberExpression('I have {int} cukes', registry)
+    const expected: StepDocument = {
+      segments: ['I have ', ['12', '17'], ' cukes'],
+      suggestion: 'I have {int} cukes',
+    }
+    const actual = buildStepDocumentFromCucumberExpression(expression, registry, {
+      int: ['12', '17'],
+    })
     assert.deepStrictEqual(actual, expected)
   })
 })

--- a/test/step-documents/buildStepDocuments.test.ts
+++ b/test/step-documents/buildStepDocuments.test.ts
@@ -9,12 +9,50 @@ import { buildStepDocuments } from '../../src/step-documents/buildStepDocuments.
 import { StepDocument } from '../../src/step-documents/types.js'
 
 describe('buildStepDocuments', () => {
+  it('builds step documents from parameter step definition without steps', () => {
+    const parameterTypeRegistry = new ParameterTypeRegistry()
+    const ef = new ExpressionFactory(parameterTypeRegistry)
+    const expression = ef.createExpression('I have {int} cukes')
+    assertStepDocuments(
+      parameterTypeRegistry,
+      [],
+      [expression],
+      [
+        {
+          suggestion: 'I have {int} cukes',
+          segments: ['I have ', [], ' cukes'],
+          expression,
+        },
+      ]
+    )
+  })
+
+  it('builds step documents from alternation step definition without steps', () => {
+    const parameterTypeRegistry = new ParameterTypeRegistry()
+    const ef = new ExpressionFactory(parameterTypeRegistry)
+    const expression = ef.createExpression('I have two/three cukes')
+    assertStepDocuments(
+      parameterTypeRegistry,
+      [],
+      [expression],
+      [
+        {
+          suggestion: 'I have two/three cukes',
+          segments: ['I have ', ['two', 'three'], ' cukes'],
+          expression,
+        },
+      ]
+    )
+  })
+
   it('builds step documents with global choices', () => {
-    const ef = new ExpressionFactory(new ParameterTypeRegistry())
+    const parameterTypeRegistry = new ParameterTypeRegistry()
+    const ef = new ExpressionFactory(parameterTypeRegistry)
     const e1 = ef.createExpression('The {word} song')
     const e2 = ef.createExpression('The {word} boat')
 
     assertStepDocuments(
+      parameterTypeRegistry,
       ['The nice song', 'The big boat'],
       [e1, e2],
       [
@@ -33,9 +71,11 @@ describe('buildStepDocuments', () => {
   })
 
   it('builds step documents from CucumberExpression', () => {
-    const ef = new ExpressionFactory(new ParameterTypeRegistry())
+    const parameterTypeRegistry = new ParameterTypeRegistry()
+    const ef = new ExpressionFactory(parameterTypeRegistry)
     const expression = ef.createExpression('I have {int} cukes in/on my {word}')
     assertStepDocuments(
+      parameterTypeRegistry,
       [
         'I have 42 cukes in my belly',
         'I have 54 cukes on my table',
@@ -58,9 +98,11 @@ describe('buildStepDocuments', () => {
   })
 
   it('builds step documents from RegularExpression', () => {
-    const ef = new ExpressionFactory(new ParameterTypeRegistry())
+    const parameterTypeRegistry = new ParameterTypeRegistry()
+    const ef = new ExpressionFactory(parameterTypeRegistry)
     const expression = ef.createExpression(/I have (\d\d) cukes in my "(belly|suitcase)"/)
     assertStepDocuments(
+      parameterTypeRegistry,
       ['I have 42 cukes in my "belly"', 'I have 54 cukes in my "suitcase"'],
       [expression],
       [
@@ -74,9 +116,11 @@ describe('buildStepDocuments', () => {
   })
 
   it('builds step documents with a max number of choices', () => {
-    const ef = new ExpressionFactory(new ParameterTypeRegistry())
+    const parameterTypeRegistry = new ParameterTypeRegistry()
+    const ef = new ExpressionFactory(parameterTypeRegistry)
     const expression = ef.createExpression('I have {int} cukes in/on my {word}')
     assertStepDocuments(
+      parameterTypeRegistry,
       [
         'I have 42 cukes in my belly',
         'I have 54 cukes on my table',
@@ -102,11 +146,17 @@ describe('buildStepDocuments', () => {
 })
 
 function assertStepDocuments(
+  parameterTypeRegistry: ParameterTypeRegistry,
   stepTexts: readonly string[],
   expressions: readonly Expression[],
   expectedStepDocuments: StepDocument[],
   maxChoices = 10
 ) {
-  const stepDocuments = buildStepDocuments(stepTexts, expressions, maxChoices)
+  const stepDocuments = buildStepDocuments(
+    parameterTypeRegistry,
+    stepTexts,
+    expressions,
+    maxChoices
+  )
   assert.deepStrictEqual(stepDocuments, expectedStepDocuments)
 }

--- a/test/step-documents/buildStepDocuments.test.ts
+++ b/test/step-documents/buildStepDocuments.test.ts
@@ -9,7 +9,7 @@ import { buildStepDocuments } from '../../src/step-documents/buildStepDocuments.
 import { StepDocument } from '../../src/step-documents/types.js'
 
 describe('buildStepDocuments', () => {
-  it('builds step documents from parameter step definition without steps', () => {
+  xit('builds step documents from parameter step definition without steps', () => {
     const parameterTypeRegistry = new ParameterTypeRegistry()
     const ef = new ExpressionFactory(parameterTypeRegistry)
     const expression = ef.createExpression('I have {int} cukes')
@@ -27,7 +27,7 @@ describe('buildStepDocuments', () => {
     )
   })
 
-  it('builds step documents from alternation step definition without steps', () => {
+  xit('builds step documents from alternation step definition without steps', () => {
     const parameterTypeRegistry = new ParameterTypeRegistry()
     const ef = new ExpressionFactory(parameterTypeRegistry)
     const expression = ef.createExpression('I have two/three cukes')

--- a/test/step-documents/buildStepDocuments.test.ts
+++ b/test/step-documents/buildStepDocuments.test.ts
@@ -21,7 +21,6 @@ describe('buildStepDocuments', () => {
         {
           suggestion: 'I have {int} cukes',
           segments: ['I have ', [], ' cukes'],
-          expression,
         },
       ]
     )
@@ -39,7 +38,6 @@ describe('buildStepDocuments', () => {
         {
           suggestion: 'I have two/three cukes',
           segments: ['I have ', ['two', 'three'], ' cukes'],
-          expression,
         },
       ]
     )
@@ -59,12 +57,10 @@ describe('buildStepDocuments', () => {
         {
           suggestion: 'The {word} boat',
           segments: ['The ', ['big', 'nice'], ' boat'],
-          expression: e2,
         },
         {
           suggestion: 'The {word} song',
           segments: ['The ', ['big', 'nice'], ' song'],
-          expression: e1,
         },
       ]
     )
@@ -84,14 +80,15 @@ describe('buildStepDocuments', () => {
       [expression],
       [
         {
-          suggestion: 'I have {int} cukes in my {word}',
-          segments: ['I have ', ['42', '54'], ' cukes in my ', ['basket', 'belly', 'table']],
-          expression,
-        },
-        {
-          suggestion: 'I have {int} cukes on my {word}',
-          segments: ['I have ', ['42', '54'], ' cukes on my ', ['basket', 'belly', 'table']],
-          expression,
+          suggestion: 'I have {int} cukes in/on my {word}',
+          segments: [
+            'I have ',
+            ['42', '54'],
+            ' cukes ',
+            ['in', 'on'],
+            ' my ',
+            ['basket', 'belly', 'table'],
+          ],
         },
       ]
     )
@@ -107,9 +104,8 @@ describe('buildStepDocuments', () => {
       [expression],
       [
         {
-          suggestion: 'I have {} cukes in my "{}"',
+          suggestion: 'I have (\\d\\d) cukes in my "(belly|suitcase)"',
           segments: ['I have ', ['42', '54'], ' cukes in my "', ['belly', 'suitcase'], '"'],
-          expression,
         },
       ]
     )
@@ -130,14 +126,8 @@ describe('buildStepDocuments', () => {
       [expression],
       [
         {
-          suggestion: 'I have {int} cukes in my {word}',
-          segments: ['I have ', ['42', '54'], ' cukes in my ', ['basket', 'belly']],
-          expression,
-        },
-        {
-          suggestion: 'I have {int} cukes on my {word}',
-          segments: ['I have ', ['42', '54'], ' cukes on my ', ['basket', 'belly']],
-          expression,
+          suggestion: 'I have {int} cukes in/on my {word}',
+          segments: ['I have ', ['42', '54'], ' cukes ', ['in', 'on'], ' my ', ['basket', 'belly']],
         },
       ],
       2

--- a/test/step-documents/buildStepDocumentsFromRegularExpression.test.ts
+++ b/test/step-documents/buildStepDocumentsFromRegularExpression.test.ts
@@ -1,0 +1,42 @@
+import { ParameterTypeRegistry, RegularExpression } from '@cucumber/cucumber-expressions'
+import assert from 'assert'
+
+import { buildStepDocumentsFromRegularExpression } from '../../src/step-documents/buildStepDocumentsFromRegularExpression.js'
+import { StepDocument } from '../../src/step-documents/types.js'
+
+describe('buildStepDocumentsFromRegularExpression', () => {
+  let registry: ParameterTypeRegistry
+  beforeEach(() => {
+    registry = new ParameterTypeRegistry()
+  })
+
+  it('builds an item from a plain expression', () => {
+    const expression = new RegularExpression(/I have 4 cukes/, registry)
+    const expected: StepDocument = {
+      segments: ['I have 4 cukes'],
+      suggestion: 'I have 4 cukes',
+    }
+    const actual = buildStepDocumentsFromRegularExpression(
+      expression,
+      registry,
+      ['I have 4 cukes'],
+      {}
+    )
+    assert.deepStrictEqual(actual, [expected])
+  })
+
+  it('builds an item from an expression with a group', () => {
+    const expression = new RegularExpression(/I have (\d+) cukes/, registry)
+    const expected: StepDocument = {
+      segments: ['I have ', ['12'], ' cukes'],
+      suggestion: 'I have (\\d+) cukes',
+    }
+    const actual = buildStepDocumentsFromRegularExpression(
+      expression,
+      registry,
+      ['I have 4 cukes'],
+      { '-?\\d+|\\d+': ['12'] }
+    )
+    assert.deepStrictEqual(actual, [expected])
+  })
+})


### PR DESCRIPTION
### 🤔 What's changed?

Improved ability to generate steps (`StepDocument`) from {Cucumber|Regular}Expressions that don't yet have any matching steps.

This code relies on https://github.com/cucumber/cucumber-expressions/pull/108.

### ⚡️ What's your motivation? 

Fix #16

### 🏷️ What kind of change is this?

- :boom: Breaking change (incompatible changes to the API)

### ♻️ Anything particular you want feedback on?

It may be a good idea to also handle the generation of step documents for optionals and alternation in the same fix. The code in `buildStepDocuments` is rather complex and could need some simplification.

