### PR TITLE
Escape lsp snippets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+- Fixed escaping of LSP snippets ([#34](https://github.com/cucumber/language-service/pull/34))
+
 ### Added
 - Added back wasm support that was deleted in 0.13.0 ([#33](https://github.com/cucumber/language-service/pull/33)) 
 

--- a/src/service/snippet/lspCompletionSnippet.ts
+++ b/src/service/snippet/lspCompletionSnippet.ts
@@ -13,6 +13,8 @@ export function lspCompletionSnippet(segments: SuggestionSegments): string {
 }
 
 function lspPlaceholder(i: number, choices: readonly string[]) {
+  // Escape $ } \ , | in choices
+  // https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#grammar
   const escapedChoices = choices
     .filter((choice) => choice !== '')
     .map((choice) => choice.replace(/([$\\},|])/g, '\\$1'))

--- a/src/service/snippet/lspCompletionSnippet.ts
+++ b/src/service/snippet/lspCompletionSnippet.ts
@@ -1,5 +1,5 @@
 /**
- * Generates an [LSP Completion Snippet]{@link https://microsoft.github.io/language-server-protocol/specifications/specification-3-17/#snippet_syntax}
+ * Generates an [LSP Completion Snippet]{@link https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#snippet_syntax}
  *
  * @param expression the expression to generate the snippet from
  */
@@ -13,5 +13,8 @@ export function lspCompletionSnippet(segments: SuggestionSegments): string {
 }
 
 function lspPlaceholder(i: number, choices: readonly string[]) {
-  return `\${${i}|${choices.join(',')}|}`
+  const escapedChoices = choices
+    .filter((choice) => choice !== '')
+    .map((choice) => choice.replace(/([$\\},|])/g, '\\$1'))
+  return `\${${i}|${escapedChoices.join(',')}|}`
 }

--- a/test/service/snippet/lspCompletionSnippet.test.ts
+++ b/test/service/snippet/lspCompletionSnippet.test.ts
@@ -4,7 +4,7 @@ import { lspCompletionSnippet } from '../../../src/service/snippet/lspCompletion
 import { SuggestionSegments } from '../../../src/suggestions/types.js'
 
 describe('lspCompletionSnippet', () => {
-  it('converts StepSegments to an LSP snippet', () => {
+  it('converts segments to an LSP snippet', () => {
     const segments: SuggestionSegments = [
       'I have ',
       ['42', '54'],
@@ -15,5 +15,15 @@ describe('lspCompletionSnippet', () => {
       lspCompletionSnippet(segments),
       'I have ${1|42,54|} cukes in my ${2|basket,belly,table|}'
     )
+  })
+
+  it('removes empty suggestions', () => {
+    const segments: SuggestionSegments = ['I have cuke', ['s', '']]
+    assert.strictEqual(lspCompletionSnippet(segments), 'I have cuke${1|s|}')
+  })
+
+  it('escapes special characters', () => {
+    const segments: SuggestionSegments = ['the choices are ', ['', '$', '\\', '}', ',', '|']]
+    assert.strictEqual(lspCompletionSnippet(segments), 'the choices are ${1|\\$,\\\\,\\},\\,,\\||}')
   })
 })

--- a/test/suggestions/buildSuggestionFromCucumberExpression.test.ts
+++ b/test/suggestions/buildSuggestionFromCucumberExpression.test.ts
@@ -33,7 +33,7 @@ describe('buildSuggestionFromCucumberExpression', () => {
   it('builds an item from optional expression', () => {
     const expression = new CucumberExpression('I have 1 cuke(s)', registry)
     const expected: Suggestion = {
-      segments: ['I have 1 cuke', ['s', '']],
+      segments: ['I have 1 ', ['cuke', 'cukes']],
       label: 'I have 1 cuke(s)',
     }
     const actual = buildSuggestionFromCucumberExpression(expression, registry, {})
@@ -75,7 +75,7 @@ describe('buildSuggestionFromCucumberExpression', () => {
   it('builds an item from complex expression', () => {
     const expression = new CucumberExpression('I have {int} cuke(s) in my bag/belly', registry)
     const expected: Suggestion = {
-      segments: ['I have ', ['12'], ' cuke', ['s', ''], ' in my ', ['bag', 'belly']],
+      segments: ['I have ', ['12'], ' ', ['cuke', 'cukes'], ' in my ', ['bag', 'belly']],
       label: 'I have {int} cuke(s) in my bag/belly',
     }
     const actual = buildSuggestionFromCucumberExpression(expression, registry, {


### PR DESCRIPTION
### 🤔 What's changed?

LSP snippets are correctly escaped

### ⚡️ What's your motivation? 

Fix #26 

### 🏷️ What kind of change is this?

- :bug: Bug fix (non-breaking change which fixes a defect)

### 📋 Checklist:

<!--- 
This is to help you remember all the little things we often forget to do!

Feel free to delete any tasks that are not relevant, or add new ones.
-->

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)
- [x] I've changed the behaviour of the code
  - [x] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [x] Users should know about my change
  - [x] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../CHANGELOG.md), linking to this pull request.

----

*This text was originally generated from a [template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates), then edited by hand. [You can modify the template here.](https://github.com/cucumber/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
