### PR TITLE
Add ParserAdapter#init() to public API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## Changed
+- Add `ParserAdapter#init()` to public API
+
 ## [0.14.4] - 2022-04-25
 
 ## Fixed

--- a/src/tree-sitter-node/NodeParserAdapter.ts
+++ b/src/tree-sitter-node/NodeParserAdapter.ts
@@ -30,4 +30,8 @@ export class NodeParserAdapter implements ParserAdapter {
         throw new Error(`Unsupported language: ${language}`)
     }
   }
+
+  init(): Promise<void> {
+    return Promise.resolve(undefined)
+  }
 }

--- a/src/tree-sitter-wasm/WasmParserAdapter.ts
+++ b/src/tree-sitter-wasm/WasmParserAdapter.ts
@@ -7,14 +7,16 @@ export class WasmParserAdapter implements ParserAdapter {
   public parser: NodeParser
   private languages: Record<LanguageName, Parser.Language>
 
-  async init(wasmBaseUrl: string) {
+  constructor(private readonly wasmBaseUrl: string) {}
+
+  async init() {
     await Parser.init()
     // @ts-ignore
     this.parser = new Parser()
 
     const languages = await Promise.all(
       LanguageNames.map((languageName) => {
-        const wasmUrl = `${wasmBaseUrl}/${languageName}.wasm`
+        const wasmUrl = `${this.wasmBaseUrl}/${languageName}.wasm`
         return Parser.Language.load(wasmUrl)
       })
     )

--- a/src/tree-sitter/types.ts
+++ b/src/tree-sitter/types.ts
@@ -22,6 +22,7 @@ export type TreeSitterLanguage = {
  */
 export interface ParserAdapter {
   readonly parser: Parser
+  init(): Promise<void>
   setLanguage(language: LanguageName): void
   query(source: string): Parser.Query
 }

--- a/test/tree-sitter/ExpressionBuilder.test.ts
+++ b/test/tree-sitter/ExpressionBuilder.test.ts
@@ -11,10 +11,11 @@ import { WasmParserAdapter } from '../../src/tree-sitter-wasm/WasmParserAdapter.
 
 const parameterTypeSupport: Set<LanguageName> = new Set(['typescript', 'java'])
 
-function defineContract(makeParserAdapter: () => Promise<ParserAdapter>) {
+function defineContract(makeParserAdapter: () => ParserAdapter) {
   let expressionBuilder: ExpressionBuilder
   beforeEach(async () => {
     const parserAdpater = await makeParserAdapter()
+    await parserAdpater.init()
     expressionBuilder = new ExpressionBuilder(parserAdpater)
   })
 
@@ -39,14 +40,10 @@ function defineContract(makeParserAdapter: () => Promise<ParserAdapter>) {
 
 describe('ExpressionBuilder', () => {
   context('with NodeParserAdapter', () => {
-    defineContract(() => Promise.resolve(new NodeParserAdapter()))
+    defineContract(() => new NodeParserAdapter())
   })
 
   context('with WasmParserAdapter', () => {
-    defineContract(async () => {
-      const wasmParserAdapter = new WasmParserAdapter()
-      await wasmParserAdapter.init('dist')
-      return wasmParserAdapter
-    })
+    defineContract(() => new WasmParserAdapter('dist'))
   })
 })


### PR DESCRIPTION
### 🤔 What's changed?

Add `ParserAdapter#init()`

### ⚡️ What's your motivation? 

To be able to initialize the parser in language-server without needing to know whether the implementation is wasm or node

### 🏷️ What kind of change is this?

<!--- Delete any options that are not relevant -->

- :boom: Breaking change (incompatible changes to the API)
