### PR TITLE
Add label details

### DIFF
--- a/src/service/getGherkinCompletionItems.ts
+++ b/src/service/getGherkinCompletionItems.ts
@@ -10,7 +10,7 @@ export function getGherkinCompletionItems(
   gherkinSource: string,
   line: number,
   index: Index
-): CompletionItem[] {
+): readonly CompletionItem[] {
   const { gherkinDocument } = parseGherkinDocument(gherkinSource)
   if (!gherkinDocument) {
     return []
@@ -29,22 +29,28 @@ export function getGherkinCompletionItems(
   })
   if (text === undefined) return []
   const suggestions = index(text)
-  return suggestions.map((suggestion) => ({
-    label: suggestion.label,
-    insertTextFormat: InsertTextFormat.Snippet,
-    kind: CompletionItemKind.Text,
-    textEdit: {
-      newText: lspCompletionSnippet(suggestion.segments),
-      range: {
-        start: {
-          line,
-          character: startCharacter,
-        },
-        end: {
-          line,
-          character: endCharacter,
+  return suggestions.map((suggestion) => {
+    const item: CompletionItem = {
+      label: suggestion.label,
+      insertTextFormat: InsertTextFormat.Snippet,
+      kind: CompletionItemKind.Text,
+      labelDetails: {
+        ...(suggestion.matched ? {} : { detail: ' (undefined step)' }),
+      },
+      textEdit: {
+        newText: lspCompletionSnippet(suggestion.segments),
+        range: {
+          start: {
+            line,
+            character: startCharacter,
+          },
+          end: {
+            line,
+            character: endCharacter,
+          },
         },
       },
-    },
-  }))
+    }
+    return item
+  })
 }

--- a/src/suggestions/buildSuggestionFromCucumberExpression.ts
+++ b/src/suggestions/buildSuggestionFromCucumberExpression.ts
@@ -19,6 +19,7 @@ export function buildSuggestionFromCucumberExpression(
   return {
     label: expression.source,
     segments,
+    matched: true,
   }
 }
 

--- a/src/suggestions/buildSuggestions.ts
+++ b/src/suggestions/buildSuggestions.ts
@@ -73,6 +73,7 @@ export function buildSuggestions(
     suggestions.push({
       label: stepText,
       segments: [stepText],
+      matched: false,
     })
   }
 

--- a/src/suggestions/buildSuggestionsFromRegularExpression.ts
+++ b/src/suggestions/buildSuggestionsFromRegularExpression.ts
@@ -39,5 +39,6 @@ export function buildSuggestionsFromRegularExpression(
   return [...segmentJsons].sort().map((s, n) => ({
     segments: JSON.parse(s) as SuggestionSegment[],
     label: n == 0 ? expression.source : `${expression.source} (${n + 1})`,
+    matched: true,
   }))
 }

--- a/src/suggestions/types.ts
+++ b/src/suggestions/types.ts
@@ -12,6 +12,11 @@ export type Suggestion = {
    * lspCompletionSnippet function.
    */
   segments: SuggestionSegments
+
+  /**
+   * True is this suggestion is from a matched step
+   */
+  matched: boolean
 }
 
 export type SuggestionSegments = readonly SuggestionSegment[]

--- a/test/index/Index.test.ts
+++ b/test/index/Index.test.ts
@@ -12,10 +12,12 @@ function verifyIndexContract(name: string, buildIndex: BuildIndex) {
       const s1: Suggestion = {
         label: 'I have {int} cukes in my belly',
         segments: ['I have ', ['42', '98'], ' cukes in my belly'],
+        matched: true,
       }
       const s2: Suggestion = {
         label: 'I am a teapot',
         segments: ['I am a teapot'],
+        matched: true,
       }
       let index: Index
       beforeEach(() => {
@@ -55,6 +57,7 @@ function verifyIndexContract(name: string, buildIndex: BuildIndex) {
                 return {
                   label: sentence,
                   segments: [sentence],
+                  matched: false,
                 }
               })
             const index = buildIndex(allSuggestions)

--- a/test/messages/MessagesBuilder.test.ts
+++ b/test/messages/MessagesBuilder.test.ts
@@ -67,6 +67,7 @@ describe('MessagesBuilder', () => {
       {
         segments: ['I select the ', ['2nd'], ' snippet'],
         label: 'I select the {ordinal} snippet',
+        matched: true,
       },
       {
         segments: [
@@ -74,14 +75,17 @@ describe('MessagesBuilder', () => {
           ['"I have ${1|11,17,23|} cukes on my ${2|belly,table,tree|}"', '"cukes"'],
         ],
         label: 'I type {string}',
+        matched: true,
       },
       {
         segments: ['the following Gherkin step texts exist:'],
         label: 'the following Gherkin step texts exist:',
+        matched: true,
       },
       {
         segments: ['the following Step Definitions exist:'],
         label: 'the following Step Definitions exist:',
+        matched: true,
       },
       {
         segments: [
@@ -89,14 +93,17 @@ describe('MessagesBuilder', () => {
           ['"I have ${1|11,17,23|} cukes on my ${2|belly,table,tree|}"', '"cukes"'],
         ],
         label: 'the LSP snippet should be {string}',
+        matched: true,
       },
       {
         segments: ['the suggestions should be empty'],
         label: 'the suggestions should be empty',
+        matched: true,
       },
       {
         segments: ['the suggestions should be:'],
         label: 'the suggestions should be:',
+        matched: true,
       },
     ]
     assert.deepStrictEqual(result!.suggestions, expectedSuggestions)

--- a/test/service/getGherkinCompletionItems.test.ts
+++ b/test/service/getGherkinCompletionItems.test.ts
@@ -6,7 +6,7 @@ import { getGherkinCompletionItems } from '../../src/service/getGherkinCompletio
 import { Suggestion } from '../../src/suggestions/types.js'
 
 describe('getGherkinCompletionItems', () => {
-  it('completes with step text', () => {
+  it('completes matched step', () => {
     const s1: Suggestion = {
       label: 'I have {int} cukes in my belly',
       segments: ['I have ', ['42', '98'], ' cukes in my belly'],
@@ -48,7 +48,7 @@ describe('getGherkinCompletionItems', () => {
     assert.deepStrictEqual(completions, expectedCompletions)
   })
 
-  it('completes with step text', () => {
+  it('completes unmatched step', () => {
     const s1: Suggestion = {
       label: 'I have {int} cukes in my belly',
       segments: ['I have ', ['42', '98'], ' cukes in my belly'],

--- a/test/service/getGherkinCompletionItems.test.ts
+++ b/test/service/getGherkinCompletionItems.test.ts
@@ -7,16 +7,18 @@ import { Suggestion } from '../../src/suggestions/types.js'
 
 describe('getGherkinCompletionItems', () => {
   it('completes with step text', () => {
-    const doc1: Suggestion = {
+    const s1: Suggestion = {
       label: 'I have {int} cukes in my belly',
       segments: ['I have ', ['42', '98'], ' cukes in my belly'],
+      matched: true,
     }
-    const doc2: Suggestion = {
+    const s2: Suggestion = {
       label: 'I am a teapot',
       segments: ['I am a teapot'],
+      matched: true,
     }
 
-    const index = bruteForceIndex([doc1, doc2])
+    const index = bruteForceIndex([s1, s2])
     const gherkinSource = `Feature: Hello
   Scenario: World
     Given cukes
@@ -27,6 +29,7 @@ describe('getGherkinCompletionItems', () => {
         label: 'I have {int} cukes in my belly',
         insertTextFormat: InsertTextFormat.Snippet,
         kind: CompletionItemKind.Text,
+        labelDetails: {},
         textEdit: {
           newText: 'I have ${1|42,98|} cukes in my belly',
           range: {
@@ -37,6 +40,50 @@ describe('getGherkinCompletionItems', () => {
             end: {
               line: 2,
               character: 15,
+            },
+          },
+        },
+      },
+    ]
+    assert.deepStrictEqual(completions, expectedCompletions)
+  })
+
+  it('completes with step text', () => {
+    const s1: Suggestion = {
+      label: 'I have {int} cukes in my belly',
+      segments: ['I have ', ['42', '98'], ' cukes in my belly'],
+      matched: true,
+    }
+    const s2: Suggestion = {
+      label: 'I am a teapot',
+      segments: ['I am a teapot'],
+      matched: false,
+    }
+
+    const index = bruteForceIndex([s1, s2])
+    const gherkinSource = `Feature: Hello
+  Scenario: World
+    Given teapot
+`
+    const completions = getGherkinCompletionItems(gherkinSource, 2, index)
+    const expectedCompletions: CompletionItem[] = [
+      {
+        label: 'I am a teapot',
+        insertTextFormat: InsertTextFormat.Snippet,
+        kind: CompletionItemKind.Text,
+        labelDetails: {
+          detail: ' (undefined step)',
+        },
+        textEdit: {
+          newText: 'I am a teapot',
+          range: {
+            start: {
+              line: 2,
+              character: 10,
+            },
+            end: {
+              line: 2,
+              character: 16,
             },
           },
         },

--- a/test/suggestions/buildStepDocuments.test.ts
+++ b/test/suggestions/buildStepDocuments.test.ts
@@ -23,10 +23,12 @@ describe('buildSuggestions', () => {
         {
           label: 'The {word} boat',
           segments: ['The ', ['big', 'nice'], ' boat'],
+          matched: true,
         },
         {
           label: 'The {word} song',
           segments: ['The ', ['big', 'nice'], ' song'],
+          matched: true,
         },
       ]
     )
@@ -55,6 +57,7 @@ describe('buildSuggestions', () => {
             ' my ',
             ['basket', 'belly', 'table'],
           ],
+          matched: true,
         },
       ]
     )
@@ -72,6 +75,7 @@ describe('buildSuggestions', () => {
         {
           label: 'I have (\\d\\d) cukes in my "(belly|suitcase)"',
           segments: ['I have ', ['42', '54'], ' cukes in my "', ['belly', 'suitcase'], '"'],
+          matched: true,
         },
       ]
     )
@@ -94,6 +98,7 @@ describe('buildSuggestions', () => {
         {
           label: 'I have {int} cukes in/on my {word}',
           segments: ['I have ', ['42', '54'], ' cukes ', ['in', 'on'], ' my ', ['basket', 'belly']],
+          matched: true,
         },
       ],
       2
@@ -115,14 +120,17 @@ describe('buildSuggestions', () => {
         {
           label: 'I have 42 cukes in my belly',
           segments: ['I have 42 cukes in my belly'],
+          matched: false,
         },
         {
           label: 'I have 54 cukes in my basket',
           segments: ['I have 54 cukes in my basket'],
+          matched: false,
         },
         {
           label: 'I have 54 cukes on my table',
           segments: ['I have 54 cukes on my table'],
+          matched: false,
         },
       ]
     )

--- a/test/suggestions/buildStepDocumentsFromRegularExpression.test.ts
+++ b/test/suggestions/buildStepDocumentsFromRegularExpression.test.ts
@@ -15,6 +15,7 @@ describe('buildSuggestionsFromRegularExpression', () => {
     const expected: Suggestion = {
       segments: ['I have 4 cukes'],
       label: 'I have 4 cukes',
+      matched: true,
     }
     const actual = buildSuggestionsFromRegularExpression(
       expression,
@@ -30,6 +31,7 @@ describe('buildSuggestionsFromRegularExpression', () => {
     const expected: Suggestion = {
       segments: ['I have ', ['12'], ' cukes'],
       label: 'I have (\\d+) cukes',
+      matched: true,
     }
     const actual = buildSuggestionsFromRegularExpression(expression, registry, ['I have 4 cukes'], {
       '-?\\d+|\\d+': ['12'],

--- a/test/suggestions/buildSuggestionFromCucumberExpression.test.ts
+++ b/test/suggestions/buildSuggestionFromCucumberExpression.test.ts
@@ -15,6 +15,7 @@ describe('buildSuggestionFromCucumberExpression', () => {
     const expected: Suggestion = {
       segments: ['I have 4 cukes'],
       label: 'I have 4 cukes',
+      matched: true,
     }
     const actual = buildSuggestionFromCucumberExpression(expression, registry, {})
     assert.deepStrictEqual(actual, expected)
@@ -25,6 +26,7 @@ describe('buildSuggestionFromCucumberExpression', () => {
     const expected: Suggestion = {
       segments: ['I have ', ['4', '5'], ' cukes'],
       label: 'I have 4/5 cukes',
+      matched: true,
     }
     const actual = buildSuggestionFromCucumberExpression(expression, registry, {})
     assert.deepStrictEqual(actual, expected)
@@ -35,6 +37,7 @@ describe('buildSuggestionFromCucumberExpression', () => {
     const expected: Suggestion = {
       segments: ['I have 1 ', ['cuke', 'cukes']],
       label: 'I have 1 cuke(s)',
+      matched: true,
     }
     const actual = buildSuggestionFromCucumberExpression(expression, registry, {})
     assert.deepStrictEqual(actual, expected)
@@ -45,6 +48,7 @@ describe('buildSuggestionFromCucumberExpression', () => {
     const expected: Suggestion = {
       segments: ['I have ', ['12', '17'], ' cukes'],
       label: 'I have {int} cukes',
+      matched: true,
     }
     const actual = buildSuggestionFromCucumberExpression(expression, registry, {
       int: ['12', '17'],
@@ -57,6 +61,7 @@ describe('buildSuggestionFromCucumberExpression', () => {
     const expected: Suggestion = {
       segments: ['I have ', ['0'], ' cukes'],
       label: 'I have {int} cukes',
+      matched: true,
     }
     const actual = buildSuggestionFromCucumberExpression(expression, registry, {})
     assert.deepStrictEqual(actual, expected)
@@ -67,6 +72,7 @@ describe('buildSuggestionFromCucumberExpression', () => {
     const expected: Suggestion = {
       segments: [['me', 'you']],
       label: 'me/you',
+      matched: true,
     }
     const actual = buildSuggestionFromCucumberExpression(expression, registry, {})
     assert.deepStrictEqual(actual, expected)
@@ -77,6 +83,7 @@ describe('buildSuggestionFromCucumberExpression', () => {
     const expected: Suggestion = {
       segments: ['I have ', ['12'], ' ', ['cuke', 'cukes'], ' in my ', ['bag', 'belly']],
       label: 'I have {int} cuke(s) in my bag/belly',
+      matched: true,
     }
     const actual = buildSuggestionFromCucumberExpression(expression, registry, {
       int: ['12'],


### PR DESCRIPTION
### 🤔 What's changed?

This adds a `(undefined step)` [label detail](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#completionItemLabelDetails) to suggestions from unmatched/undefined steps

### ⚡️ What's your motivation? 

When we fixed #40, users will see unmatched steps as suggestions. This is great, but we should give a hint that using this suggestion will insert an undefined step.

### 🏷️ What kind of change is this?

- :zap: New feature (non-breaking change which adds new behaviour)
