### PR TITLE
Add getGenerateSnippetCodeActions

### DIFF
--- a/src/service/getGenerateSnippetCodeActions.ts
+++ b/src/service/getGenerateSnippetCodeActions.ts
@@ -1,0 +1,51 @@
+import { CucumberExpressionGenerator, ParameterTypeRegistry } from '@cucumber/cucumber-expressions'
+import {
+  CodeAction,
+  CodeActionKind,
+  CreateFile,
+  Diagnostic,
+  TextDocumentEdit,
+  TextEdit,
+  VersionedTextDocumentIdentifier,
+} from 'vscode-languageserver-types'
+
+import { getLanguage } from '../tree-sitter/languages.js'
+import { LanguageName } from '../tree-sitter/types.js'
+
+export function getGenerateSnippetCodeActions(
+  diagnostics: Diagnostic[],
+  uri: string,
+  languageName: LanguageName,
+  registry: ParameterTypeRegistry
+): CodeAction[] {
+  const undefinedStepDiagnostic = diagnostics.find((d) => d.code === 'cucumber.undefined-step')
+  const stepText = undefinedStepDiagnostic?.data?.stepText
+  if (undefinedStepDiagnostic && stepText && uri) {
+    const language = getLanguage(languageName)
+    const generator = new CucumberExpressionGenerator(() => registry.parameterTypes)
+    const expressions = generator.generateExpressions(stepText)
+    const snippets = expressions.map((expression) => language.generateSnippet(expression))
+
+    const ca: CodeAction = {
+      title: 'Generate step definition',
+      diagnostics: [undefinedStepDiagnostic],
+      kind: CodeActionKind.QuickFix,
+      edit: {
+        documentChanges: [
+          CreateFile.create(uri, {
+            ignoreIfExists: true,
+            overwrite: true,
+          }),
+          ...snippets.map((snippet) =>
+            TextDocumentEdit.create(VersionedTextDocumentIdentifier.create(uri, 0), [
+              TextEdit.insert({ line: 0, character: 0 }, snippet),
+            ])
+          ),
+        ],
+      },
+      isPreferred: true,
+    }
+    return [ca]
+  }
+  return []
+}

--- a/src/service/getGherkinDiagnostics.ts
+++ b/src/service/getGherkinDiagnostics.ts
@@ -32,7 +32,7 @@ export function getGherkinDiagnostics(
           },
         },
         message: error.message,
-        source: 'ex',
+        source: 'Cucumber',
       }
       diagnostics.push(diagnostic)
     }
@@ -56,26 +56,41 @@ export function getGherkinDiagnostics(
       if (isUndefined(step.text, expressions) && step.location.column !== undefined) {
         const line = step.location.line - 1
         const character = step.location.column - 1 + step.keyword.length
-        const diagnostic: Diagnostic = {
-          severity: DiagnosticSeverity.Warning,
-          range: {
-            start: {
-              line,
-              character,
-            },
-            end: {
-              line,
-              character: character + step.text.length,
-            },
-          },
-          message: `Undefined step: ${step.text}`,
-          source: 'ex',
-        }
+        const diagnostic: Diagnostic = makeUndefinedStepDiagnostic(line, character, step.text)
         return arr.concat(diagnostic)
       }
       return arr
     },
   })
+}
+
+export function makeUndefinedStepDiagnostic(
+  line: number,
+  character: number,
+  stepText: string
+): Diagnostic {
+  return {
+    severity: DiagnosticSeverity.Warning,
+    range: {
+      start: {
+        line,
+        character,
+      },
+      end: {
+        line,
+        character: character + stepText.length,
+      },
+    },
+    message: `Undefined step: ${stepText}`,
+    source: 'Cucumber',
+    code: 'cucumber.undefined-step',
+    codeDescription: {
+      href: 'https://cucumber.io/docs/cucumber/step-definitions/',
+    },
+    data: {
+      stepText,
+    },
+  }
 }
 
 function isUndefined(stepText: string, expressions: readonly Expression[]): boolean {

--- a/src/service/index.ts
+++ b/src/service/index.ts
@@ -1,3 +1,4 @@
+export * from './getGenerateSnippetCodeActions.js'
 export * from './getGherkinCompletionItems.js'
 export * from './getGherkinDiagnostics.js'
 export * from './getGherkinFormattingEdits.js'

--- a/src/tree-sitter/csharpLanguage.ts
+++ b/src/tree-sitter/csharpLanguage.ts
@@ -1,3 +1,5 @@
+import { GeneratedExpression } from '@cucumber/cucumber-expressions'
+
 import { TreeSitterLanguage } from './types.js'
 
 export const csharpLanguage: TreeSitterLanguage = {
@@ -22,9 +24,17 @@ export const csharpLanguage: TreeSitterLanguage = {
 )
 `,
   ],
-  toStringOrRegExp(s: string): string | RegExp {
+  toStringOrRegExp(s) {
     const match = s.match(/^([@$'"]+)(.*)"$/)
     if (!match) throw new Error(`Could not match ${s}`)
     return new RegExp(match[2])
+  },
+
+  generateSnippet(expression: GeneratedExpression): string {
+    return `
+        [Given(@"${expression.source}")]
+        public void todo_rename() {
+        }
+`
   },
 }

--- a/src/tree-sitter/javaLanguage.ts
+++ b/src/tree-sitter/javaLanguage.ts
@@ -1,3 +1,5 @@
+import { GeneratedExpression } from '@cucumber/cucumber-expressions'
+
 import { TreeSitterLanguage } from './types.js'
 
 export const javaLanguage: TreeSitterLanguage = {
@@ -77,5 +79,13 @@ export const javaLanguage: TreeSitterLanguage = {
     const match = s.match(/^"(\^.*\$)"$/)
     if (match) return new RegExp(match[1])
     return s.substring(1, s.length - 1)
+  },
+
+  generateSnippet(expression: GeneratedExpression): string {
+    return `
+        [Given(@"${expression.source}")]
+        public void todo_rename() {
+        }
+`
   },
 }

--- a/src/tree-sitter/languages.ts
+++ b/src/tree-sitter/languages.ts
@@ -1,0 +1,18 @@
+import { csharpLanguage } from './csharpLanguage.js'
+import { javaLanguage } from './javaLanguage.js'
+import { phpLanguage } from './phpLanguage.js'
+import { rubyLanguage } from './rubyLanguage.js'
+import { LanguageName, TreeSitterLanguage } from './types.js'
+import { typescriptLanguage } from './typescriptLanguage.js'
+
+const treeSitterLanguageByName: Record<LanguageName, TreeSitterLanguage> = {
+  java: javaLanguage,
+  typescript: typescriptLanguage,
+  c_sharp: csharpLanguage,
+  php: phpLanguage,
+  ruby: rubyLanguage,
+}
+
+export function getLanguage(languageName: LanguageName): TreeSitterLanguage {
+  return treeSitterLanguageByName[languageName]
+}

--- a/src/tree-sitter/phpLanguage.ts
+++ b/src/tree-sitter/phpLanguage.ts
@@ -1,3 +1,5 @@
+import { GeneratedExpression } from '@cucumber/cucumber-expressions'
+
 import { TreeSitterLanguage } from './types.js'
 
 export const phpLanguage: TreeSitterLanguage = {
@@ -16,5 +18,13 @@ export const phpLanguage: TreeSitterLanguage = {
     const match = s.match(/^(\/\*\*[\s*]*)([\s\S]*)(\n[\s]*\*\/)/)
     if (!match) throw new Error(`Could not match ${s}`)
     return new RegExp(match[2].replace(/@(Given |When |Then )/, '').trim())
+  },
+
+  generateSnippet(expression: GeneratedExpression): string {
+    return `
+        [Given(@"${expression.source}")]
+        public void todo_rename() {
+        }
+`
   },
 }

--- a/src/tree-sitter/rubyLanguage.ts
+++ b/src/tree-sitter/rubyLanguage.ts
@@ -1,3 +1,5 @@
+import { GeneratedExpression } from '@cucumber/cucumber-expressions'
+
 import { TreeSitterLanguage } from './types.js'
 
 export const rubyLanguage: TreeSitterLanguage = {
@@ -55,5 +57,13 @@ export const rubyLanguage: TreeSitterLanguage = {
     if (!match) throw new Error(`Could not match '${s}'`)
     if (match[1] === '/' && match[3] === '/') return new RegExp(match[2])
     return match[2]
+  },
+
+  generateSnippet(expression: GeneratedExpression): string {
+    return `
+        [Given(@"${expression.source}")]
+        public void todo_rename() {
+        }
+`
   },
 }

--- a/src/tree-sitter/types.ts
+++ b/src/tree-sitter/types.ts
@@ -1,4 +1,8 @@
-import { Expression } from '@cucumber/cucumber-expressions'
+import {
+  Expression,
+  GeneratedExpression,
+  ParameterTypeRegistry,
+} from '@cucumber/cucumber-expressions'
 import Parser from 'tree-sitter'
 
 export type ParameterTypeMeta = { name: string; regexp: string }
@@ -16,11 +20,13 @@ export type TreeSitterLanguage = {
   defineParameterTypeQueries: readonly string[]
   defineStepDefinitionQueries: readonly string[]
   toStringOrRegExp(expression: string): string | RegExp
+  generateSnippet(expression: GeneratedExpression): string
 }
 
 export type ExpressionBuilderResult = {
   readonly expressions: readonly Expression[]
   readonly errors: readonly Error[]
+  readonly registry: ParameterTypeRegistry
 }
 
 /**

--- a/src/tree-sitter/typescriptLanguage.ts
+++ b/src/tree-sitter/typescriptLanguage.ts
@@ -1,3 +1,5 @@
+import { GeneratedExpression } from '@cucumber/cucumber-expressions'
+
 import { TreeSitterLanguage } from './types.js'
 
 export const typescriptLanguage: TreeSitterLanguage = {
@@ -57,5 +59,12 @@ export const typescriptLanguage: TreeSitterLanguage = {
     if (!match) throw new Error(`Could not match ${s}`)
     if (match[1] === '/' && match[3] === '/') return new RegExp(match[2])
     return match[2]
+  },
+
+  generateSnippet(expression: GeneratedExpression): string {
+    return `
+Given('${expression.source}', function (arg0: number) {
+})
+`
   },
 }

--- a/test/service/getGenerateSnippetCodeActions.test.ts
+++ b/test/service/getGenerateSnippetCodeActions.test.ts
@@ -1,0 +1,110 @@
+import { ParameterTypeRegistry } from '@cucumber/cucumber-expressions'
+import assert from 'assert'
+import { CodeAction } from 'vscode-languageserver-types'
+
+import { getGenerateSnippetCodeActions } from '../../src/service/getGenerateSnippetCodeActions.js'
+import { makeUndefinedStepDiagnostic } from '../../src/service/getGherkinDiagnostics.js'
+
+describe('getGenerateSnippetCodeActions', () => {
+  it('generates code', () => {
+    const diagnostic = makeUndefinedStepDiagnostic(10, 4, 'I have 43 cukes')
+    const actions = getGenerateSnippetCodeActions(
+      [diagnostic],
+      'features/step_defnitions/steps.ts',
+      'typescript',
+      new ParameterTypeRegistry()
+    )
+    const expectedActions: CodeAction[] = [
+      {
+        title: 'Generate step definition',
+        diagnostics: [
+          {
+            severity: 2,
+            range: {
+              start: {
+                line: 10,
+                character: 4,
+              },
+              end: {
+                line: 10,
+                character: 19,
+              },
+            },
+            message: 'Undefined step: I have 43 cukes',
+            source: 'Cucumber',
+            code: 'cucumber.undefined-step',
+            codeDescription: {
+              href: 'https://cucumber.io/docs/cucumber/step-definitions/',
+            },
+            data: {
+              stepText: 'I have 43 cukes',
+            },
+          },
+        ],
+        kind: 'quickfix',
+        edit: {
+          documentChanges: [
+            {
+              kind: 'create',
+              uri: 'features/step_defnitions/steps.ts',
+              options: {
+                ignoreIfExists: true,
+                overwrite: true,
+              },
+            },
+            {
+              textDocument: {
+                uri: 'features/step_defnitions/steps.ts',
+                version: 0,
+              },
+              edits: [
+                {
+                  range: {
+                    start: {
+                      line: 0,
+                      character: 0,
+                    },
+                    end: {
+                      line: 0,
+                      character: 0,
+                    },
+                  },
+                  newText: `
+Given('I have {int} cukes', function (arg0: number) {
+})
+`,
+                },
+              ],
+            },
+            {
+              textDocument: {
+                uri: 'features/step_defnitions/steps.ts',
+                version: 0,
+              },
+              edits: [
+                {
+                  range: {
+                    start: {
+                      line: 0,
+                      character: 0,
+                    },
+                    end: {
+                      line: 0,
+                      character: 0,
+                    },
+                  },
+                  newText: `
+Given('I have {float} cukes', function (arg0: number) {
+})
+`,
+                },
+              ],
+            },
+          ],
+        },
+        isPreferred: true,
+      },
+    ]
+    assert.deepStrictEqual(actions, expectedActions)
+  })
+})

--- a/test/service/getGherkinDiagnostics.test.ts
+++ b/test/service/getGherkinDiagnostics.test.ts
@@ -31,7 +31,7 @@ describe('getGherkinDiagnostics', () => {
           },
         },
         severity: DiagnosticSeverity.Error,
-        source: 'ex',
+        source: 'Cucumber',
       },
     ])
   })
@@ -61,7 +61,7 @@ describe('getGherkinDiagnostics', () => {
           },
         },
         severity: DiagnosticSeverity.Error,
-        source: 'ex',
+        source: 'Cucumber',
       },
     ]
     assert.deepStrictEqual(diagnostics, expectedDiagnostics)
@@ -77,6 +77,13 @@ describe('getGherkinDiagnostics', () => {
     )
     const expectedDiagnostics: Diagnostic[] = [
       {
+        code: 'cucumber.undefined-step',
+        codeDescription: {
+          href: 'https://cucumber.io/docs/cucumber/step-definitions/',
+        },
+        data: {
+          stepText: 'an undefined step',
+        },
         message: 'Undefined step: an undefined step',
         range: {
           start: {
@@ -89,7 +96,7 @@ describe('getGherkinDiagnostics', () => {
           },
         },
         severity: DiagnosticSeverity.Warning,
-        source: 'ex',
+        source: 'Cucumber',
       },
     ]
     assert.deepStrictEqual(diagnostics, expectedDiagnostics)


### PR DESCRIPTION
### 🤔 What's changed?

Add a new service for generating snippets for undefined steps.

* [x] Generate a new file with snippets
* [ ] Modify an existing file instead of generating a new one
* [ ] Use a template language for snippets

### ⚡️ What's your motivation? 

Users want a quick fix (`.⌘`) for undefined steps

### 🏷️ What kind of change is this?

- :zap: New feature (non-breaking change which adds new behaviour)

