### PR TITLE
Unescape Java RegExp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 
 ### Fixed
-- Fix parsing of Java regular expressions by unescaping `\\` to `\`.
+- Fix parsing of Java regular expressions by unescaping `\\` to `\`. ([#51](https://github.com/cucumber/language-service/pull/51))
 
 ## [0.23.0] - 2022-05-24
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+- Fix parsing of Java regular expressions by unescaping `\\` to `\`.
+
 ## [0.23.0] - 2022-05-24
 ### Changed
 - Generate a single code action with relative path ([#50](https://github.com/cucumber/language-service/pull/50))

--- a/src/language/ExpressionBuilder.ts
+++ b/src/language/ExpressionBuilder.ts
@@ -85,8 +85,8 @@ export class ExpressionBuilder {
         continue
       }
 
-      const treeSitterLanguage = getLanguage(source.languageName)
-      for (const defineParameterTypeQuery of treeSitterLanguage.defineParameterTypeQueries) {
+      const language = getLanguage(source.languageName)
+      for (const defineParameterTypeQuery of language.defineParameterTypeQueries) {
         const query = this.parserAdapter.query(defineParameterTypeQuery)
         const matches = query.matches(tree.rootNode)
         for (const match of matches) {
@@ -96,7 +96,7 @@ export class ExpressionBuilder {
           if (nameNode && expressionNode && rootNode) {
             const parameterType = makeParameterType(
               toString(nameNode.text),
-              treeSitterLanguage.toStringOrRegExp(expressionNode.text)
+              language.convertParameterTypeExpression(expressionNode.text)
             )
             defineParameterType(parameterType)
             const locationLink = createLocationLink(rootNode, expressionNode, source.path)
@@ -121,7 +121,9 @@ export class ExpressionBuilder {
           const expressionNode = syntaxNode(match, 'expression')
           const rootNode = syntaxNode(match, 'root')
           if (expressionNode && rootNode) {
-            const stringOrRegexp = treeSitterLanguage.toStringOrRegExp(expressionNode.text)
+            const stringOrRegexp = treeSitterLanguage.convertStepDefinitionExpression(
+              expressionNode.text
+            )
             try {
               const expression = expressionFactory.createExpression(stringOrRegexp)
               const locationLink = createLocationLink(rootNode, expressionNode, source.path)
@@ -154,7 +156,7 @@ function syntaxNode(match: Parser.QueryMatch, name: string): SyntaxNode | undefi
 }
 
 function makeParameterType(name: string, regexp: string | RegExp) {
-  return new ParameterType(name, regexp, Object, () => undefined, false, false)
+  return new ParameterType(name, regexp, Object, () => undefined, true, false)
 }
 
 function sortLinks<L extends Link>(links: L[]): readonly L[] {

--- a/src/language/ExpressionBuilder.ts
+++ b/src/language/ExpressionBuilder.ts
@@ -156,7 +156,7 @@ function syntaxNode(match: Parser.QueryMatch, name: string): SyntaxNode | undefi
 }
 
 function makeParameterType(name: string, regexp: string | RegExp) {
-  return new ParameterType(name, regexp, Object, () => undefined, true, false)
+  return new ParameterType(name, regexp, Object, (arg) => arg, true, false)
 }
 
 function sortLinks<L extends Link>(links: L[]): readonly L[] {

--- a/src/language/csharpLanguage.ts
+++ b/src/language/csharpLanguage.ts
@@ -22,7 +22,8 @@ export const csharpLanguage: Language = {
 ) @root
 `,
   ],
-  convertParameterTypeExpression(_s) {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  convertParameterTypeExpression(s) {
     throw new Error('Unsupported operation')
   },
   convertStepDefinitionExpression(s) {

--- a/src/language/csharpLanguage.ts
+++ b/src/language/csharpLanguage.ts
@@ -22,7 +22,10 @@ export const csharpLanguage: Language = {
 ) @root
 `,
   ],
-  toStringOrRegExp(s) {
+  convertParameterTypeExpression(_s) {
+    throw new Error('Unsupported operation')
+  },
+  convertStepDefinitionExpression(s) {
     const match = s.match(/^([@$'"]+)(.*)"$/)
     if (!match) throw new Error(`Could not match ${s}`)
     return new RegExp(match[2])

--- a/src/language/javaLanguage.ts
+++ b/src/language/javaLanguage.ts
@@ -73,9 +73,18 @@ export const javaLanguage: Language = {
 `,
   ],
 
-  toStringOrRegExp(s: string): string | RegExp {
+  convertParameterTypeExpression(s: string): RegExp {
+    const match = s.match(/^"(.*)"$/)
+    if (!match) throw new Error(`Could not match ${s}`)
+    return unescapeRegExp(match[1])
+  },
+
+  convertStepDefinitionExpression(s: string): string | RegExp {
     const match = s.match(/^"(\^.*\$)"$/)
-    if (match) return new RegExp(match[1])
+    if (match) {
+      const regExp = unescapeRegExp(match[1])
+      return new RegExp(regExp)
+    }
     return s.substring(1, s.length - 1)
   },
 
@@ -98,4 +107,9 @@ export const javaLanguage: Language = {
         // {{ blurb }}
     }
 `,
+}
+
+// Java escapes \ as \\. Turn \\ back to \.
+function unescapeRegExp(regexp: string): RegExp {
+  return new RegExp(regexp.replace(/\\\\/g, '\\'))
 }

--- a/src/language/phpLanguage.ts
+++ b/src/language/phpLanguage.ts
@@ -11,7 +11,8 @@ export const phpLanguage: Language = {
 ) @root
 `,
   ],
-  convertParameterTypeExpression(_s: string): RegExp {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  convertParameterTypeExpression(s: string): RegExp {
     throw new Error('Unsupported operation')
   },
   convertStepDefinitionExpression(s: string): string | RegExp {

--- a/src/language/phpLanguage.ts
+++ b/src/language/phpLanguage.ts
@@ -11,7 +11,10 @@ export const phpLanguage: Language = {
 ) @root
 `,
   ],
-  toStringOrRegExp(s: string): string | RegExp {
+  convertParameterTypeExpression(_s: string): RegExp {
+    throw new Error('Unsupported operation')
+  },
+  convertStepDefinitionExpression(s: string): string | RegExp {
     // match multiline comment
     const match = s.match(/^(\/\*\*[\s*]*)([\s\S]*)(\n[\s]*\*\/)/)
     if (!match) throw new Error(`Could not match ${s}`)
@@ -37,7 +40,7 @@ export const phpLanguage: Language = {
      */
     public function {{ snakeName }}({{ #parameters }}{{ #seenParameter }}, {{ /seenParameter }}{{ name }}{{ /parameters }})
     {
-      // {{ blurb }}
+        // {{ blurb }}
     }
 `,
 }

--- a/src/language/rubyLanguage.ts
+++ b/src/language/rubyLanguage.ts
@@ -50,11 +50,12 @@ export const rubyLanguage: Language = {
 `,
   ],
 
-  toStringOrRegExp(s: string): string | RegExp {
-    const match = s.match(/^([/'"])(.*)([/'"])$/)
-    if (!match) throw new Error(`Could not match '${s}'`)
-    if (match[1] === '/' && match[3] === '/') return new RegExp(match[2])
-    return match[2]
+  convertParameterTypeExpression(expression: string) {
+    return toStringOrRegExp(expression)
+  },
+
+  convertStepDefinitionExpression(s: string) {
+    return toStringOrRegExp(s)
   },
 
   snippetParameters: {
@@ -76,4 +77,11 @@ export const rubyLanguage: Language = {
   // {{ blurb }}
 end
 `,
+}
+
+function toStringOrRegExp(s: string): string | RegExp {
+  const match = s.match(/^([/'"])(.*)([/'"])$/)
+  if (!match) throw new Error(`Could not match '${s}'`)
+  if (match[1] === '/' && match[3] === '/') return new RegExp(match[2])
+  return match[2]
 }

--- a/src/language/types.ts
+++ b/src/language/types.ts
@@ -44,7 +44,8 @@ export type Language = {
   readonly defineParameterTypeQueries: readonly string[]
   readonly defineStepDefinitionQueries: readonly string[]
   readonly snippetParameters: SnippetParameters
-  toStringOrRegExp(expression: string): string | RegExp
+  convertStepDefinitionExpression(expression: string): string | RegExp
+  convertParameterTypeExpression(expression: string): string | RegExp
 }
 
 export type ExpressionBuilderResult = {

--- a/src/language/typescriptLanguage.ts
+++ b/src/language/typescriptLanguage.ts
@@ -52,11 +52,12 @@ export const typescriptLanguage: Language = {
 `,
   ],
 
-  toStringOrRegExp(s: string): string | RegExp {
-    const match = s.match(/^([/'"])(.*)([/'"])$/)
-    if (!match) throw new Error(`Could not match ${s}`)
-    if (match[1] === '/' && match[3] === '/') return new RegExp(match[2])
-    return match[2]
+  convertParameterTypeExpression(s: string) {
+    return toStringOrRegExp(s)
+  },
+
+  convertStepDefinitionExpression(s: string) {
+    return toStringOrRegExp(s)
   },
 
   snippetParameters: {
@@ -78,4 +79,11 @@ export const typescriptLanguage: Language = {
   // {{ blurb }}
 })
 `,
+}
+
+function toStringOrRegExp(s: string): string | RegExp {
+  const match = s.match(/^([/'"])(.*)([/'"])$/)
+  if (!match) throw new Error(`Could not match ${s}`)
+  if (match[1] === '/' && match[3] === '/') return new RegExp(match[2])
+  return match[2]
 }

--- a/test/language/ExpressionBuilder.test.ts
+++ b/test/language/ExpressionBuilder.test.ts
@@ -69,11 +69,9 @@ Please register a ParameterType for 'undefined-parameter'`,
         // Verify that the extracted expressions actually work
         let matched = false
         for (const expressionLink of result.expressionLinks) {
-          const cukexp =
-            expressionLink.expression instanceof CucumberExpression
-              ? expressionLink.expression
-              : undefined
-          if (expressionLink.expression.match('a 2020-12-24')) {
+          const match = expressionLink.expression.match('a 2020-12-24')
+          if (match) {
+            assert.strictEqual(match[0].getValue(undefined), '2020-12-24')
             matched = true
           }
         }

--- a/test/language/ExpressionBuilder.test.ts
+++ b/test/language/ExpressionBuilder.test.ts
@@ -21,7 +21,7 @@ function defineContract(makeParserAdapter: () => ParserAdapter) {
 
   for (const dir of glob.sync(`test/language/testdata/*`)) {
     const languageName = basename(dir) as LanguageName
-    // if (language !== 'ruby') {
+    // if (languageName !== 'php') {
     //   continue
     // }
     it(`builds parameter types and expressions from ${languageName} source`, async () => {
@@ -65,6 +65,19 @@ an {undefined-parameter}
 Undefined parameter type 'undefined-parameter'.
 Please register a ParameterType for 'undefined-parameter'`,
         ])
+
+        // Verify that the extracted expressions actually work
+        let matched = false
+        for (const expressionLink of result.expressionLinks) {
+          const cukexp =
+            expressionLink.expression instanceof CucumberExpression
+              ? expressionLink.expression
+              : undefined
+          if (expressionLink.expression.match('a 2020-12-24')) {
+            matched = true
+          }
+        }
+        assert(matched, 'The generated expressions did not match parameter type {date}')
       } else {
         assert.deepStrictEqual(expressions, [/^a regexp$/])
         assert.deepStrictEqual(errors, ['There is already a parameter type with name int'])


### PR DESCRIPTION
### 🤔 What's changed?

Java RegExps extracted from source are unescaped before turned into a JavaScript regexp.

### ⚡️ What's your motivation? 

Fix a bug where custom parameter types did not match.

### 🏷️ What kind of change is this?

- :bug: Bug fix (non-breaking change which fixes a defect)

### 📋 Checklist:

<!--- 
This is to help you remember all the little things we often forget to do!

Feel free to delete any tasks that are not relevant, or add new ones.
-->

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)
- [x] I've changed the behaviour of the code
  - [x] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [x] Users should know about my change
  - [x] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../CHANGELOG.md), linking to this pull request.
