### PR TITLE
Improve templating. Fixes #52. Fixes #53.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+* Undefined `And` and `But` steps now generate the correct `Given`, `When` or `Then` keyword, based on parent step(s) ([#54](https://github.com/cucumber/language-service/pull/54))
+* Parameters are excluded from method names ([#54](https://github.com/cucumber/language-service/pull/54))
+* Generated C# step definitions include the keyword in the method name ([#54](https://github.com/cucumber/language-service/pull/54))
+
+### Changed
+* The mustache templating syntax now uses different variables ([#54](https://github.com/cucumber/language-service/pull/54))
+
 ## [0.23.1] - 2022-05-25
 ### Fixed
 - Fix parsing of Java regular expressions by unescaping `\\` to `\`. ([#51](https://github.com/cucumber/language-service/pull/51))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
-### Fixed
-* Undefined `And` and `But` steps now generate the correct `Given`, `When` or `Then` keyword, based on parent step(s) ([#54](https://github.com/cucumber/language-service/pull/54))
-* Parameters are excluded from method names ([#54](https://github.com/cucumber/language-service/pull/54))
-* Generated C# step definitions include the keyword in the method name ([#54](https://github.com/cucumber/language-service/pull/54))
-
+## [0.24.0] - 2022-05-25
 ### Changed
-* The mustache templating syntax now uses different variables ([#54](https://github.com/cucumber/language-service/pull/54))
+- The mustache templating syntax now uses different variables ([#54](https://github.com/cucumber/language-service/pull/54))
+
+### Fixed
+- Undefined `And` and `But` steps now generate the correct `Given`, `When` or `Then` keyword, based on parent step(s) ([#54](https://github.com/cucumber/language-service/pull/54))
+- Parameters are excluded from method names ([#54](https://github.com/cucumber/language-service/pull/54))
+- Generated C# step definitions include the keyword in the method name ([#54](https://github.com/cucumber/language-service/pull/54))
 
 ## [0.23.1] - 2022-05-25
 ### Fixed
@@ -204,7 +205,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ([#1732](https://github.com/cucumber/common/pull/1732)
 [aslakhellesoy](https://github.com/aslakhellesoy))
 
-[Unreleased]: https://github.com/cucumber/language-service/compare/v0.23.1...HEAD
+[Unreleased]: https://github.com/cucumber/language-service/compare/v0.24.0...HEAD
+[0.24.0]: https://github.com/cucumber/language-service/compare/v0.23.1...v0.24.0
 [0.23.1]: https://github.com/cucumber/language-service/compare/v0.23.0...v0.23.1
 [0.23.0]: https://github.com/cucumber/language-service/compare/v0.22.2...v0.23.0
 [0.22.2]: https://github.com/cucumber/language-service/compare/v0.22.1...v0.22.2

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cucumber/language-service",
-  "version": "0.23.1",
+  "version": "0.24.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@cucumber/language-service",
-      "version": "0.23.1",
+      "version": "0.24.0",
       "license": "MIT",
       "dependencies": {
         "@cucumber/cucumber-expressions": "^15.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cucumber/language-service",
-  "version": "0.23.1",
+  "version": "0.24.0",
   "description": "Cucumber Language Service",
   "type": "module",
   "main": "dist/cjs/src/index.js",

--- a/src/language/csharpLanguage.ts
+++ b/src/language/csharpLanguage.ts
@@ -47,8 +47,9 @@ export const csharpLanguage: Language = {
   },
 
   defaultSnippetTemplate: `
-    [{{ stepKeyword }}("{{ expression }}")]
-    public void {{ camelName }}({{ #parameters }}{{ #seenParameter }}, {{ /seenParameter }}{{ type }} {{ name }}{{ /parameters }})
+    // This step definition uses Cucumber Expressions. See https://github.com/gasparnagy/CucumberExpressions.SpecFlow
+    [{{ keyword }}("{{ expression }}")]
+    public void {{ #capitalize }}{{ #camelize }}{{ keyword }} {{expression}}{{ /camelize }}{{ /capitalize }}({{ #parameters }}{{ #seenParameter }}, {{ /seenParameter }}{{ type }} {{ name }}{{ /parameters }})
     {
         // {{ blurb }}
     }

--- a/src/language/javaLanguage.ts
+++ b/src/language/javaLanguage.ts
@@ -102,8 +102,8 @@ export const javaLanguage: Language = {
     '': { type: 'Object', name: 'arg' },
   },
   defaultSnippetTemplate: `
-    @{{ stepKeyword }}("{{ expression }}")
-    public void {{ snakeName }}({{ #parameters }}{{ #seenParameter }}, {{ /seenParameter }}{{ type }} {{ name }}{{ /parameters }}) {
+    @{{ keyword }}("{{ expression }}")
+    public void {{ #underscore }}{{ expression }}{{ /underscore }}({{ #parameters }}{{ #seenParameter }}, {{ /seenParameter }}{{ type }} {{ name }}{{ /parameters }}) {
         // {{ blurb }}
     }
 `,

--- a/src/language/phpLanguage.ts
+++ b/src/language/phpLanguage.ts
@@ -37,9 +37,9 @@ export const phpLanguage: Language = {
   },
   defaultSnippetTemplate: `
     /**
-     * {{ stepKeyword }} {{ expression }}
+     * {{ keyword }} {{ expression }}
      */
-    public function {{ snakeName }}({{ #parameters }}{{ #seenParameter }}, {{ /seenParameter }}{{ name }}{{ /parameters }})
+    public function {{ #camelize }}{{ expression }}{{ /camelize }}({{ #parameters }}{{ #seenParameter }}, {{ /seenParameter }}{{ name }}{{ /parameters }})
     {
         // {{ blurb }}
     }

--- a/src/language/rubyLanguage.ts
+++ b/src/language/rubyLanguage.ts
@@ -73,7 +73,7 @@ export const rubyLanguage: Language = {
   },
 
   defaultSnippetTemplate: `
-{{ stepKeyword }}('{{ expression }}') do |{{ #parameters }}{{ #seenParameter }}, {{ /seenParameter }}{{ name }}{{ /parameters }}|
+{{ keyword }}('{{ expression }}') do |{{ #parameters }}{{ #seenParameter }}, {{ /seenParameter }}{{ name }}{{ /parameters }}|
   // {{ blurb }}
 end
 `,

--- a/src/language/typescriptLanguage.ts
+++ b/src/language/typescriptLanguage.ts
@@ -75,7 +75,7 @@ export const typescriptLanguage: Language = {
   },
 
   defaultSnippetTemplate: `
-{{ stepKeyword }}('{{ expression }}', ({{ #parameters }}{{ #seenParameter }}, {{ /seenParameter }}{{ name }}: {{ type }}{{ /parameters }}) => {
+{{ keyword }}('{{ expression }}', ({{ #parameters }}{{ #seenParameter }}, {{ /seenParameter }}{{ name }}: {{ type }}{{ /parameters }}) => {
   // {{ blurb }}
 })
 `,

--- a/src/service/getGenerateSnippetCodeAction.ts
+++ b/src/service/getGenerateSnippetCodeAction.ts
@@ -37,7 +37,7 @@ export function getGenerateSnippetCodeAction(
 ): CodeAction | null {
   const undefinedStepDiagnostic = diagnostics.find((d) => d.code === diagnosticCodeUndefinedStep)
   const language = getLanguage(languageName)
-  const stepKeyword = undefinedStepDiagnostic?.data?.stepKeyword
+  const snippetKeyword = undefinedStepDiagnostic?.data?.snippetKeyword
   const stepText = undefinedStepDiagnostic?.data?.stepText
   if (!undefinedStepDiagnostic || !stepText) {
     return null
@@ -46,7 +46,7 @@ export function getGenerateSnippetCodeAction(
   const generatedExpressions = generator.generateExpressions(stepText)
 
   const snippet = stepDefinitionSnippet(
-    stepKeyword,
+    snippetKeyword,
     generatedExpressions,
     mustacheTemplate || language.defaultSnippetTemplate,
     language.snippetParameters

--- a/src/service/snippet/stepDefinitionSnippet.ts
+++ b/src/service/snippet/stepDefinitionSnippet.ts
@@ -3,14 +3,17 @@ import mustache from 'mustache'
 
 import { ParameterTypeName, SnippetParameters } from '../../language'
 
+type MustacheFunction = () => (text: string, render: (text: string) => string) => string
+
 type TemplateContext = {
-  stepKeyword: string
-  camelName: string
-  snakeName: string
+  keyword: string
   expression: string
   parameters: readonly Parameter[]
   seenParameter: () => boolean
   blurb: string
+  camelize: MustacheFunction
+  underscore: MustacheFunction
+  capitalize: MustacheFunction
 }
 
 type Parameter = {
@@ -18,29 +21,43 @@ type Parameter = {
   type: string
 }
 
+function toWords(expression: string) {
+  return expression
+    .replace(/{[^}]*}/g, ' ')
+    .replace(/[^a-zA-Z_]+/g, ' ')
+    .trim()
+    .split(/\s+/)
+}
+
+const camelize: MustacheFunction = () => (text, render) =>
+  toWords(render(text))
+    .map((word, i) => (i === 0 ? word.toLowerCase() : word[0].toUpperCase() + word.slice(1)))
+    .join('')
+
+const underscore: MustacheFunction = () => (text, render) =>
+  toWords(render(text))
+    .map((word, i) => (i === 0 ? word : `_${word}`))
+    .join('')
+
+const capitalize: MustacheFunction = () => (text, render) => {
+  const rendered = render(text)
+  return rendered[0].toUpperCase() + rendered.slice(1)
+}
+
 const blurb = 'Write code here that turns the phrase above into concrete actions'
 
 export function stepDefinitionSnippet(
-  stepKeyword: string,
+  keyword: string,
   generatedExpressions: readonly GeneratedExpression[],
   mustacheTemplate: string,
   snippetParameters: SnippetParameters
 ): string {
   // TODO: Add the remaining ones as comments
   const generatedExpression = generatedExpressions[0]
-  const words = generatedExpression.source
-    .replace(/[^a-zA-Z_]+/g, ' ')
-    .trim()
-    .split(/\s+/)
-  const camelName = words
-    .map((word, i) => (i === 0 ? word.toLowerCase() : word[0].toUpperCase() + word.slice(1)))
-    .join('')
-  const snakeName = words.map((word, i) => (i === 0 ? word : `_${word}`)).join('')
+
   let _seenParameter = false
   const context: TemplateContext = {
-    stepKeyword: stepKeyword.trim(), // Remove the trailing space - never used in code generation
-    camelName,
-    snakeName,
+    keyword: keyword.trim(), // Remove the trailing space - never used in code generation
     expression: generatedExpression.source,
     parameters: generatedExpression.parameterInfos.map((parameterInfo) => {
       const snippetParameter = snippetParameters[(parameterInfo.name as ParameterTypeName) || '']
@@ -59,6 +76,9 @@ export function stepDefinitionSnippet(
       }
     },
     blurb,
+    camelize,
+    underscore,
+    capitalize,
   }
   return mustache.render(mustacheTemplate, context)
 }

--- a/test/service/getGenerateSnippetCodeAction.test.ts
+++ b/test/service/getGenerateSnippetCodeAction.test.ts
@@ -7,7 +7,7 @@ import { makeUndefinedStepDiagnostic } from '../../src/service/getGherkinDiagnos
 
 describe('getGenerateSnippetCodeAction', () => {
   it('generates code in a new file', () => {
-    const diagnostic = makeUndefinedStepDiagnostic(10, 4, 'Given ', 'I have 43 cukes')
+    const diagnostic = makeUndefinedStepDiagnostic(10, 4, 'And ', 'I have 43 cukes', 'Given ')
 
     const targetRange = Range.create(10, 0, 10, 0)
     const link: LocationLink = {
@@ -46,7 +46,7 @@ describe('getGenerateSnippetCodeAction', () => {
             href: 'https://cucumber.io/docs/cucumber/step-definitions/',
           },
           data: {
-            stepKeyword: 'Given ',
+            snippetKeyword: 'Given ',
             stepText: 'I have 43 cukes',
           },
         },
@@ -96,7 +96,7 @@ Given('I have {int} cukes', (int: number) => {
   })
 
   it('generates code in an existing file', () => {
-    const diagnostic = makeUndefinedStepDiagnostic(10, 4, 'Given ', 'I have 43 cukes')
+    const diagnostic = makeUndefinedStepDiagnostic(10, 4, 'But ', 'I have 43 cukes', 'Given ')
 
     const targetRange = Range.create(10, 0, 10, 0)
     const link: LocationLink = {
@@ -136,7 +136,7 @@ Given('I have {int} cukes', (int: number) => {
             href: 'https://cucumber.io/docs/cucumber/step-definitions/',
           },
           data: {
-            stepKeyword: 'Given ',
+            snippetKeyword: 'Given ',
             stepText: 'I have 43 cukes',
           },
         },

--- a/test/service/getGherkinDiagnostics.test.ts
+++ b/test/service/getGherkinDiagnostics.test.ts
@@ -71,9 +71,10 @@ describe('getGherkinDiagnostics', () => {
     const diagnostics = getGherkinDiagnostics(
       `Feature: Hello
   Scenario: Hi
-    Given an undefined step
+    Given a defined step
+    And an undefined step
 `,
-      []
+      [new CucumberExpression('a defined step', new ParameterTypeRegistry())]
     )
     const expectedDiagnostics: Diagnostic[] = [
       {
@@ -82,18 +83,18 @@ describe('getGherkinDiagnostics', () => {
           href: 'https://cucumber.io/docs/cucumber/step-definitions/',
         },
         data: {
-          stepKeyword: 'Given ',
+          snippetKeyword: 'Given ',
           stepText: 'an undefined step',
         },
         message: 'Undefined step: an undefined step',
         range: {
           start: {
-            line: 2,
-            character: 10,
+            line: 3,
+            character: 8,
           },
           end: {
-            line: 2,
-            character: 27,
+            line: 3,
+            character: 25,
           },
         },
         severity: DiagnosticSeverity.Warning,

--- a/test/service/snippet/stepDefinitionSnippet.test.ts
+++ b/test/service/snippet/stepDefinitionSnippet.test.ts
@@ -9,6 +9,7 @@ import { NodeParserAdapter } from '../../../src/tree-sitter-node/NodeParserAdapt
 
 describe('stepDefinitionSnippet', () => {
   for (const languageName of Object.values(LanguageNames)) {
+    // if (languageName !== 'c_sharp') continue
     it(`generates a snippet for ${languageName}`, () => {
       const registry = new ParameterTypeRegistry()
       const generator = new CucumberExpressionGenerator(() => registry.parameterTypes)
@@ -26,10 +27,9 @@ describe('stepDefinitionSnippet', () => {
       const result = expressionBuilder.build([source], [])
       if (result.expressionLinks.length === 1) {
         assert.strictEqual(result.expressionLinks[0].expression.source, '{int} is not {int}')
-      } else {
-        console.log(`### Manually verify that this is valid ${languageName}:`)
-        console.log(snippet)
       }
+      console.log(`### Manually verify that this is valid ${languageName}:`)
+      console.log(snippet)
     })
   }
 })


### PR DESCRIPTION
### 🤔 What's changed?

* Undefined `And` and `But` steps now generate the correct `Given`, `When` or `Then` keyword, based on parent step(s)  
* Parameters are excluded from method names
* Generated C# step definitions include the keyword in the method name
* Generally improve the mustache templating syntax

### ⚡️ What's your motivation? 

Fix #52 and #53 

### 🏷️ What kind of change is this?

- :bug: Bug fix (non-breaking change which fixes a defect)

### 📋 Checklist:

<!--- 
This is to help you remember all the little things we often forget to do!

Feel free to delete any tasks that are not relevant, or add new ones.
-->

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)
- [x] I've changed the behaviour of the code
  - [x] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [x] Users should know about my change
  - [x] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../CHANGELOG.md), linking to this pull request.

