### PR TITLE
Rename Source.path to Source.uri

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+- Remove dependency on Node `path` from `ExpressionBuilder` in order to make the library work in a browser
+
+### Changed
+- `Source.path` has been renamed to `Source.uri`
+
 ## [0.24.1] - 2022-05-25
 ### Fixed
 - Fix handling of `And` and `But` which wasn't properly fixed in `0.24.0`

--- a/src/language/types.ts
+++ b/src/language/types.ts
@@ -1,6 +1,6 @@
 import { Expression, ParameterType, ParameterTypeRegistry } from '@cucumber/cucumber-expressions'
 import Parser from 'tree-sitter'
-import { LocationLink } from 'vscode-languageserver-types'
+import { DocumentUri, LocationLink } from 'vscode-languageserver-types'
 
 export type ParameterTypeName =
   | 'int'
@@ -35,7 +35,7 @@ export type LanguageName = typeof LanguageNames[number]
 
 export type Source<L> = {
   readonly languageName: L
-  readonly path: string
+  readonly uri: DocumentUri
   readonly content: string
 }
 

--- a/src/tree-sitter-wasm/WasmParserAdapter.ts
+++ b/src/tree-sitter-wasm/WasmParserAdapter.ts
@@ -17,7 +17,11 @@ export class WasmParserAdapter implements ParserAdapter {
     const languages = await Promise.all(
       LanguageNames.map((languageName) => {
         const wasmUrl = `${this.wasmBaseUrl}/${languageName}.wasm`
-        return Parser.Language.load(wasmUrl)
+        try {
+          return Parser.Language.load(wasmUrl)
+        } catch (err) {
+          console.error(`Failed to load ${wasmUrl}: ${err.message}`)
+        }
       })
     )
     // @ts-ignore

--- a/test/language/ExpressionBuilder.test.ts
+++ b/test/language/ExpressionBuilder.test.ts
@@ -2,7 +2,7 @@ import { CucumberExpression, RegularExpression } from '@cucumber/cucumber-expres
 import assert from 'assert'
 import { readFile } from 'fs/promises'
 import glob from 'glob'
-import { basename } from 'path'
+import { basename, resolve } from 'path'
 
 import { ExpressionBuilder, LanguageName } from '../../src/index.js'
 import { ParserAdapter, Source } from '../../src/language/types.js'
@@ -30,7 +30,7 @@ function defineContract(makeParserAdapter: () => ParserAdapter) {
           return readFile(path, 'utf-8').then((content) => ({
             languageName,
             content,
-            path,
+            uri: `file://${resolve(path)}`,
           }))
         })
       )

--- a/test/service/snippet/stepDefinitionSnippet.test.ts
+++ b/test/service/snippet/stepDefinitionSnippet.test.ts
@@ -23,7 +23,11 @@ describe('stepDefinitionSnippet', () => {
       )
 
       const expressionBuilder = new ExpressionBuilder(new NodeParserAdapter())
-      const source: Source<LanguageName> = { path: 'test.x', languageName, content: snippet }
+      const source: Source<LanguageName> = {
+        uri: 'file:///tmp/test.x',
+        languageName,
+        content: snippet,
+      }
       const result = expressionBuilder.build([source], [])
       if (result.expressionLinks.length === 1) {
         assert.strictEqual(result.expressionLinks[0].expression.source, '{int} is not {int}')


### PR DESCRIPTION
### 🤔 What's changed?

`Source.path` is changed to `Source.uri`. The `ExpressionBuilder` no longer converts a path to an uri using Node.js `path.resolve`.

### ⚡️ What's your motivation? 

Be able to use the library in a browser (`@cucumber/monaco`)

### 🏷️ What kind of change is this?

- :boom: Breaking change (incompatible changes to the API)
