### PR TITLE
Handle Cucumber Expression optionals not preceded by space in suggestions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+- Handle Cucumber Expression optionals not preceded by space in suggestions 
+
 ## [0.25.0] - 2022-05-25
 ### Changed
 - `Source.path` has been renamed to `Source.uri`

--- a/test/suggestions/buildSuggestionFromCucumberExpression.test.ts
+++ b/test/suggestions/buildSuggestionFromCucumberExpression.test.ts
@@ -1,4 +1,8 @@
-import { CucumberExpression, ParameterTypeRegistry } from '@cucumber/cucumber-expressions'
+import {
+  CucumberExpression,
+  ParameterType,
+  ParameterTypeRegistry,
+} from '@cucumber/cucumber-expressions'
 import assert from 'assert'
 
 import { buildSuggestionFromCucumberExpression } from '../../src/suggestions/buildSuggestionFromCucumberExpression.js'
@@ -10,7 +14,7 @@ describe('buildSuggestionFromCucumberExpression', () => {
     registry = new ParameterTypeRegistry()
   })
 
-  it('builds an item from plain expression', () => {
+  it('builds a suggestion from plain expression', () => {
     const expression = new CucumberExpression('I have 4 cukes', registry)
     const expected: Suggestion = {
       segments: ['I have 4 cukes'],
@@ -21,7 +25,7 @@ describe('buildSuggestionFromCucumberExpression', () => {
     assert.deepStrictEqual(actual, expected)
   })
 
-  it('builds an item from alternation expression', () => {
+  it('builds a suggestion from alternation expression', () => {
     const expression = new CucumberExpression('I have 4/5 cukes', registry)
     const expected: Suggestion = {
       segments: ['I have ', ['4', '5'], ' cukes'],
@@ -32,7 +36,7 @@ describe('buildSuggestionFromCucumberExpression', () => {
     assert.deepStrictEqual(actual, expected)
   })
 
-  it('builds an item from optional expression', () => {
+  it('builds a suggestion from optional expression', () => {
     const expression = new CucumberExpression('I have 1 cuke(s)', registry)
     const expected: Suggestion = {
       segments: ['I have 1 ', ['cuke', 'cukes']],
@@ -43,7 +47,18 @@ describe('buildSuggestionFromCucumberExpression', () => {
     assert.deepStrictEqual(actual, expected)
   })
 
-  it('builds an item from parameter expression with explicit options', () => {
+  it('does not make options for optionals preceded by space', () => {
+    const expression = new CucumberExpression('he went to  (the )hospital', registry)
+    const expected: Suggestion = {
+      segments: ['he went to  the hospital'],
+      label: 'he went to  (the )hospital',
+      matched: true,
+    }
+    const actual = buildSuggestionFromCucumberExpression(expression, registry, {})
+    assert.deepStrictEqual(actual, expected)
+  })
+
+  it('builds a suggestion from parameter expression with explicit options', () => {
     const expression = new CucumberExpression('I have {int} cukes', registry)
     const expected: Suggestion = {
       segments: ['I have ', ['12', '17'], ' cukes'],
@@ -56,7 +71,7 @@ describe('buildSuggestionFromCucumberExpression', () => {
     assert.deepStrictEqual(actual, expected)
   })
 
-  it('builds an item from int parameter expression without explicit options', () => {
+  it('builds a suggestion from int parameter expression without explicit options', () => {
     const expression = new CucumberExpression('I have {int} cukes', registry)
     const expected: Suggestion = {
       segments: ['I have ', ['0'], ' cukes'],
@@ -67,7 +82,7 @@ describe('buildSuggestionFromCucumberExpression', () => {
     assert.deepStrictEqual(actual, expected)
   })
 
-  it('builds an item from only alternation expression', () => {
+  it('builds a suggestion from only alternation expression', () => {
     const expression = new CucumberExpression('me/you', registry)
     const expected: Suggestion = {
       segments: [['me', 'you']],
@@ -78,7 +93,39 @@ describe('buildSuggestionFromCucumberExpression', () => {
     assert.deepStrictEqual(actual, expected)
   })
 
-  it('builds an item from complex expression', () => {
+  it('builds a suggestion from a custom parameter type', () => {
+    enum AssetType {
+      atlas = 'atlases',
+      audio = 'audio',
+      image = 'images',
+      prefab = 'prefabs',
+      spine = 'spine',
+    }
+
+    registry.defineParameterType(
+      new ParameterType<AssetType>(
+        'assetType',
+        /prefab|audio|image|spine|atlas/,
+        null,
+        (s: keyof typeof AssetType) => AssetType[s],
+        true,
+        false
+      )
+    )
+    const expression = new CucumberExpression('I have some {assetType}(s)', registry)
+    const actual = buildSuggestionFromCucumberExpression(expression, registry, {
+      assetType: ['prefab', 'audio', 'image', 'spine', 'atlas'],
+    })
+
+    const expected: Suggestion = {
+      segments: ['I have some ', ['prefab', 'audio', 'image', 'spine', 'atlas'], 's'],
+      label: 'I have some {assetType}(s)',
+      matched: true,
+    }
+    assert.deepStrictEqual(actual, expected)
+  })
+
+  it('builds a suggestion from complex expression', () => {
     const expression = new CucumberExpression('I have {int} cuke(s) in my bag/belly', registry)
     const expected: Suggestion = {
       segments: ['I have ', ['12'], ' ', ['cuke', 'cukes'], ' in my ', ['bag', 'belly']],

--- a/test/suggestions/buildSuggestionsFromRegularExpression.test.ts
+++ b/test/suggestions/buildSuggestionsFromRegularExpression.test.ts
@@ -10,7 +10,7 @@ describe('buildSuggestionsFromRegularExpression', () => {
     registry = new ParameterTypeRegistry()
   })
 
-  it('builds an item from a plain expression', () => {
+  it('builds suggestions from a plain expression', () => {
     const expression = new RegularExpression(/I have 4 cukes/, registry)
     const expected: Suggestion = {
       segments: ['I have 4 cukes'],
@@ -26,7 +26,7 @@ describe('buildSuggestionsFromRegularExpression', () => {
     assert.deepStrictEqual(actual, [expected])
   })
 
-  it('builds an item from an expression with a group', () => {
+  it('builds suggestions from an expression with a group', () => {
     const expression = new RegularExpression(/I have (\d+) cukes/, registry)
     const expected: Suggestion = {
       segments: ['I have ', ['12'], ' cukes'],


### PR DESCRIPTION
### 🤔 What's changed?

Optional text is now included in the suggestion unless it's preceded by a word (in which case it becomes suggestion options).

### ⚡️ What's your motivation? 

The reason we include the optional in the text is that we cannot present a `['the ', '']` option to the user (where one of the options is an empty string). It cannot be represented in an [LSP snippet choice](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#snippet_syntax)

Also, this fixes #45 

### 🏷️ What kind of change is this?

- :bug: Bug fix (non-breaking change which fixes a defect)

### 📋 Checklist:

<!--- 
This is to help you remember all the little things we often forget to do!

Feel free to delete any tasks that are not relevant, or add new ones.
-->

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)
- [x] I've changed the behaviour of the code
  - [x] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [ ] Users should know about my change
  - [ ] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../CHANGELOG.md), linking to this pull request.

----

*This text was originally generated from a [template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates), then edited by hand. [You can modify the template here.](https://github.com/cucumber/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
