### PR TITLE
Fix suggestions for regexp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+- Don't throw an error when generating suggestions for RegExp.
+
 ## [0.27.0] - 2022-05-26
 ### Fixed
 - Make all `tree-sitter-{language}` dependencies optional. They are only needed at runtime for the `NodeParserAdapter` - the

--- a/src/suggestions/buildSuggestionsFromRegularExpression.ts
+++ b/src/suggestions/buildSuggestionsFromRegularExpression.ts
@@ -24,7 +24,7 @@ export function buildSuggestionsFromRegularExpression(
         const parameterType = parameterTypes[argIndex]
 
         const key = parameterType.regexpStrings.join('|')
-        const parameterSegment = parameterChoices[key]
+        const parameterSegment = parameterChoices[key] || ['...']
         segments.push(parameterSegment)
 
         if (arg.group.end !== undefined) index = arg.group.end

--- a/test/suggestions/buildSuggestions.test.ts
+++ b/test/suggestions/buildSuggestions.test.ts
@@ -81,6 +81,24 @@ describe('buildSuggestions', () => {
     )
   })
 
+  it('builds suggestions from another RegularExpression', () => {
+    const parameterTypeRegistry = new ParameterTypeRegistry()
+    const ef = new ExpressionFactory(parameterTypeRegistry)
+    const expression = ef.createExpression(/^the price of a "(.*?)" is (\d+)c$/)
+    assertSuggestions(
+      parameterTypeRegistry,
+      ['the price of a "lemon" is 34c', 'the price of a "pear" is 48c'],
+      [expression],
+      [
+        {
+          label: '^the price of a "(.*?)" is (\\d+)c$',
+          segments: ['the price of a "', ['lemon', 'pear'], '" is ', ['...'], 'c'],
+          matched: true,
+        },
+      ]
+    )
+  })
+
   it('builds suggestions with a max number of choices', () => {
     const parameterTypeRegistry = new ParameterTypeRegistry()
     const ef = new ExpressionFactory(parameterTypeRegistry)

--- a/test/suggestions/buildSuggestionsFromRegularExpression.test.ts
+++ b/test/suggestions/buildSuggestionsFromRegularExpression.test.ts
@@ -38,4 +38,20 @@ describe('buildSuggestionsFromRegularExpression', () => {
     })
     assert.deepStrictEqual(actual, [expected])
   })
+
+  it('builds suggestions for regexp without choices', () => {
+    const expression = new RegularExpression(/^the price of a "(.*?)" is (\d+)c$/, registry)
+    const expected: Suggestion = {
+      segments: ['the price of a "', ['...'], '" is ', ['...'], 'c'],
+      label: '^the price of a "(.*?)" is (\\d+)c$',
+      matched: true,
+    }
+    const actual = buildSuggestionsFromRegularExpression(
+      expression,
+      registry,
+      ['the price of a "lemon" is 34c'],
+      {}
+    )
+    assert.deepStrictEqual(actual, [expected])
+  })
 })


### PR DESCRIPTION
### 🤔 What's changed?

Suggestions from regexps no longer throw an error

### ⚡️ What's your motivation? 

Fix #60 

### 🏷️ What kind of change is this?

- :bug: Bug fix (non-breaking change which fixes a defect)

### 📋 Checklist:

<!--- 
This is to help you remember all the little things we often forget to do!

Feel free to delete any tasks that are not relevant, or add new ones.
-->

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)
- [x] I've changed the behaviour of the code
  - [x] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [x] Users should know about my change
  - [x] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../CHANGELOG.md), linking to this pull request.

----

*This text was originally generated from a [template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates), then edited by hand. [You can modify the template here.](https://github.com/cucumber/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
