### PR TITLE
Fix/csharp cucumber expression support (II)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+- Better Cucumber Expression support for SpecFlow/C# ([#68](https://github.com/cucumber/language-service/pull/68), [#62](https://github.com/cucumber/language-service/issues/62), [#63](https://github.com/cucumber/language-service/issues/63))
+
 ## [0.29.0] - 2022-06-03
 ### Changed
 - The `tree-sitter` module is an optional dependency. This reduces the risk of installation problems on Windows and also makes the library more light weight.

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.29.0",
       "license": "MIT",
       "dependencies": {
-        "@cucumber/cucumber-expressions": "^15.2.0",
+        "@cucumber/cucumber-expressions": "^16.0.0",
         "@cucumber/gherkin": "^24.0.0",
         "@cucumber/gherkin-utils": "^8.0.0",
         "@cucumber/messages": "^19.0.0",
@@ -147,9 +147,9 @@
       }
     },
     "node_modules/@cucumber/cucumber-expressions": {
-      "version": "15.2.0",
-      "resolved": "https://registry.npmjs.org/@cucumber/cucumber-expressions/-/cucumber-expressions-15.2.0.tgz",
-      "integrity": "sha512-qAzz9ogcTuosFZYfueSTWnD6KxiIAAu09HwLwz1XhYL/MhfLjyq1iQN6mOnKln/hr2jX/U98C92VAlquhXDo7Q==",
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/@cucumber/cucumber-expressions/-/cucumber-expressions-16.0.0.tgz",
+      "integrity": "sha512-HTh+Pg7oQ5aLuCkSbD2Q6jBaE40M3R/XaLEz+UqD5d9dZRu6P38W4LTooV5bV6dZgBunlMLK8+6ug2ziYvRddw==",
       "dependencies": {
         "regexp-match-indices": "1.0.2"
       }
@@ -7298,9 +7298,9 @@
       }
     },
     "@cucumber/cucumber-expressions": {
-      "version": "15.2.0",
-      "resolved": "https://registry.npmjs.org/@cucumber/cucumber-expressions/-/cucumber-expressions-15.2.0.tgz",
-      "integrity": "sha512-qAzz9ogcTuosFZYfueSTWnD6KxiIAAu09HwLwz1XhYL/MhfLjyq1iQN6mOnKln/hr2jX/U98C92VAlquhXDo7Q==",
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/@cucumber/cucumber-expressions/-/cucumber-expressions-16.0.0.tgz",
+      "integrity": "sha512-HTh+Pg7oQ5aLuCkSbD2Q6jBaE40M3R/XaLEz+UqD5d9dZRu6P38W4LTooV5bV6dZgBunlMLK8+6ug2ziYvRddw==",
       "requires": {
         "regexp-match-indices": "1.0.2"
       }

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
   },
   "homepage": "https://github.com/cucumber/language-service#readme",
   "dependencies": {
-    "@cucumber/cucumber-expressions": "^15.2.0",
+    "@cucumber/cucumber-expressions": "^16.0.0",
     "@cucumber/gherkin": "^24.0.0",
     "@cucumber/gherkin-utils": "^8.0.0",
     "@cucumber/messages": "^19.0.0",

--- a/src/language/ExpressionBuilder.ts
+++ b/src/language/ExpressionBuilder.ts
@@ -3,21 +3,18 @@ import {
   ParameterType,
   ParameterTypeRegistry,
 } from '@cucumber/cucumber-expressions'
-import { DocumentUri, LocationLink, Range } from 'vscode-languageserver-types'
 
+import { createLocationLink, makeParameterType, sortLinks, syntaxNode } from './helpers.js'
 import { getLanguage } from './languages.js'
 import { SourceAnalyzer } from './SourceAnalyzer.js'
 import {
   ExpressionBuilderResult,
   ExpressionLink,
   Language,
-  Link,
   ParameterTypeLink,
   ParameterTypeMeta,
   ParserAdapter,
   Source,
-  TreeSitterQueryMatch,
-  TreeSitterSyntaxNode,
 } from './types.js'
 
 export class ExpressionBuilder {
@@ -28,7 +25,6 @@ export class ExpressionBuilder {
     parameterTypes: readonly ParameterTypeMeta[]
   ): ExpressionBuilderResult {
     const expressionLinks: ExpressionLink[] = []
-    const parameterTypeLinks: ParameterTypeLink[] = []
     const errors: Error[] = []
     const registry = new ParameterTypeRegistry()
     const expressionFactory = new ExpressionFactory(registry)
@@ -51,23 +47,12 @@ export class ExpressionBuilder {
       (language: Language) => language.defineParameterTypeQueries
     )
 
-    for (const { source, match } of parameterTypeMatches) {
-      const nameNode = syntaxNode(match, 'name')
-      const expressionNode = syntaxNode(match, 'expression')
-      const rootNode = syntaxNode(match, 'root')
-      if (nameNode && rootNode) {
-        // SpecFlow allows definition of parameter types (StepArgumentTransformation) without specifying an expression
-        // See https://github.com/gasparnagy/CucumberExpressions.SpecFlow/blob/a2354d2175f5c632c9ae4a421510f314efce4111/CucumberExpressions.SpecFlow.SpecFlowPlugin/Expressions/UserDefinedCucumberExpressionParameterTypeTransformation.cs#L25-L27
-        const parameterTypeExpression = expressionNode ? expressionNode.text : null
-        const language = getLanguage(source.languageName)
-        const parameterType = makeParameterType(
-          toString(nameNode.text),
-          language.convertParameterTypeExpression(parameterTypeExpression)
-        )
+    let parameterTypeLinks: ParameterTypeLink[] = []
+    for (const [language, matches] of parameterTypeMatches.entries()) {
+      const links = language.buildParameterTypeLinks(matches)
+      parameterTypeLinks = parameterTypeLinks.concat(links)
+      for (const { parameterType } of links) {
         defineParameterType(parameterType)
-        const selectionNode = expressionNode || nameNode
-        const locationLink = createLocationLink(rootNode, selectionNode, source.uri)
-        parameterTypeLinks.push({ parameterType, locationLink })
       }
     }
 
@@ -75,18 +60,20 @@ export class ExpressionBuilder {
       (language: Language) => language.defineStepDefinitionQueries
     )
 
-    for (const { source, match } of stepDefinitionMatches) {
-      const expressionNode = syntaxNode(match, 'expression')
-      const rootNode = syntaxNode(match, 'root')
-      if (expressionNode && rootNode) {
-        const language = getLanguage(source.languageName)
-        const stringOrRegexp = language.convertStepDefinitionExpression(expressionNode.text)
-        try {
-          const expression = expressionFactory.createExpression(stringOrRegexp)
-          const locationLink = createLocationLink(rootNode, expressionNode, source.uri)
-          expressionLinks.push({ expression, locationLink })
-        } catch (err) {
-          errors.push(err)
+    for (const [, sourceMatches] of stepDefinitionMatches.entries()) {
+      for (const { source, match } of sourceMatches) {
+        const expressionNode = syntaxNode(match, 'expression')
+        const rootNode = syntaxNode(match, 'root')
+        if (expressionNode && rootNode) {
+          const language = getLanguage(source.languageName)
+          const stringOrRegexp = language.convertStepDefinitionExpression(expressionNode.text)
+          try {
+            const expression = expressionFactory.createExpression(stringOrRegexp)
+            const locationLink = createLocationLink(rootNode, expressionNode, source.uri)
+            expressionLinks.push({ expression, locationLink })
+          } catch (err) {
+            errors.push(err)
+          }
         }
       }
     }
@@ -98,51 +85,4 @@ export class ExpressionBuilder {
       registry,
     }
   }
-}
-
-function toString(s: string): string {
-  const match = s.match(/^['"](.*)['"]$/)
-  if (!match) return s
-  return match[1]
-}
-
-function syntaxNode(match: TreeSitterQueryMatch, name: string): TreeSitterSyntaxNode | undefined {
-  return match.captures.find((c) => c.name === name)?.node
-}
-
-function makeParameterType(name: string, regexp: string | RegExp) {
-  return new ParameterType(name, regexp, Object, (arg) => arg, true, false)
-}
-
-function sortLinks<L extends Link>(links: L[]): readonly L[] {
-  return links.sort((a, b) => {
-    const pathComparison = a.locationLink.targetUri.localeCompare(b.locationLink.targetUri)
-    if (pathComparison !== 0) return pathComparison
-    return a.locationLink.targetRange.start.line - b.locationLink.targetRange.start.line
-  })
-}
-
-function createLocationLink(
-  rootNode: TreeSitterSyntaxNode,
-  selectionNode: TreeSitterSyntaxNode,
-  targetUri: DocumentUri
-) {
-  const targetRange: Range = Range.create(
-    rootNode.startPosition.row,
-    rootNode.startPosition.column,
-    rootNode.endPosition.row,
-    rootNode.endPosition.column
-  )
-  const targetSelectionRange: Range = Range.create(
-    selectionNode.startPosition.row,
-    selectionNode.startPosition.column,
-    selectionNode.endPosition.row,
-    selectionNode.endPosition.column
-  )
-  const locationLink: LocationLink = {
-    targetRange,
-    targetSelectionRange,
-    targetUri,
-  }
-  return locationLink
 }

--- a/src/language/ExpressionBuilder.ts
+++ b/src/language/ExpressionBuilder.ts
@@ -11,6 +11,7 @@ import {
   ExpressionBuilderResult,
   ExpressionLink,
   Language,
+  LanguageName,
   ParameterTypeLink,
   ParameterTypeMeta,
   ParserAdapter,
@@ -21,7 +22,7 @@ export class ExpressionBuilder {
   constructor(private readonly parserAdapter: ParserAdapter) {}
 
   build(
-    sources: readonly Source[],
+    sources: readonly Source<LanguageName>[],
     parameterTypes: readonly ParameterTypeMeta[]
   ): ExpressionBuilderResult {
     const expressionLinks: ExpressionLink[] = []

--- a/src/language/SourceAnalyzer.ts
+++ b/src/language/SourceAnalyzer.ts
@@ -1,19 +1,26 @@
 import { getLanguage } from './languages.js'
-import { Language, ParserAdapter, Source, TreeSitterQueryMatch, TreeSitterTree } from './types.js'
+import {
+  Language,
+  LanguageName,
+  ParserAdapter,
+  Source,
+  TreeSitterQueryMatch,
+  TreeSitterTree,
+} from './types.js'
 
 export type GetQueryStrings = (language: Language) => readonly string[]
 export type SourceMatch = {
-  source: Source
+  source: Source<LanguageName>
   match: TreeSitterQueryMatch
 }
 
 export class SourceAnalyzer {
   private readonly errors: Error[] = []
-  private readonly treeByContent = new Map<Source, TreeSitterTree>()
+  private readonly treeByContent = new Map<Source<LanguageName>, TreeSitterTree>()
 
   constructor(
     private readonly parserAdapter: ParserAdapter,
-    private readonly sources: readonly Source[]
+    private readonly sources: readonly Source<LanguageName>[]
   ) {}
 
   getSourceMatches(getQueryStrings: GetQueryStrings): Map<Language, readonly SourceMatch[]> {
@@ -49,7 +56,7 @@ export class SourceAnalyzer {
     return this.errors
   }
 
-  private parse(source: Source): TreeSitterTree {
+  private parse(source: Source<LanguageName>): TreeSitterTree {
     let tree: TreeSitterTree | undefined = this.treeByContent.get(source)
     if (!tree) {
       this.treeByContent.set(source, (tree = this.parserAdapter.parser.parse(source.content)))

--- a/src/language/SourceAnalyzer.ts
+++ b/src/language/SourceAnalyzer.ts
@@ -1,8 +1,8 @@
 import { getLanguage } from './languages.js'
 import { Language, ParserAdapter, Source, TreeSitterQueryMatch, TreeSitterTree } from './types.js'
 
-type GetQueryStrings = (language: Language) => readonly string[]
-type SourceMatch = {
+export type GetQueryStrings = (language: Language) => readonly string[]
+export type SourceMatch = {
   source: Source
   match: TreeSitterQueryMatch
 }
@@ -16,8 +16,9 @@ export class SourceAnalyzer {
     private readonly sources: readonly Source[]
   ) {}
 
-  getSourceMatches(getQueryStrings: GetQueryStrings): readonly SourceMatch[] {
-    const sourceMatches: SourceMatch[] = []
+  getSourceMatches(getQueryStrings: GetQueryStrings): Map<Language, readonly SourceMatch[]> {
+    const result = new Map<Language, SourceMatch[]>()
+    // const sourceMatches: SourceMatch[] = []
     for (const source of this.sources) {
       this.parserAdapter.setLanguageName(source.languageName)
       let tree: TreeSitterTree
@@ -35,11 +36,13 @@ export class SourceAnalyzer {
         const query = this.parserAdapter.query(queryString)
         const matches = query.matches(tree.rootNode)
         for (const match of matches) {
+          const sourceMatches: SourceMatch[] = result.get(language) || []
+          result.set(language, sourceMatches)
           sourceMatches.push({ source, match })
         }
       }
     }
-    return sourceMatches
+    return result
   }
 
   getErrors(): readonly Error[] {

--- a/src/language/SourceAnalyzer.ts
+++ b/src/language/SourceAnalyzer.ts
@@ -1,0 +1,56 @@
+import { getLanguage } from './languages.js'
+import { Language, ParserAdapter, Source, TreeSitterQueryMatch, TreeSitterTree } from './types.js'
+
+type GetQueryStrings = (language: Language) => readonly string[]
+type SourceMatch = {
+  source: Source
+  match: TreeSitterQueryMatch
+}
+
+export class SourceAnalyzer {
+  private readonly errors: Error[] = []
+  private readonly treeByContent = new Map<Source, TreeSitterTree>()
+
+  constructor(
+    private readonly parserAdapter: ParserAdapter,
+    private readonly sources: readonly Source[]
+  ) {}
+
+  getSourceMatches(getQueryStrings: GetQueryStrings): readonly SourceMatch[] {
+    const sourceMatches: SourceMatch[] = []
+    for (const source of this.sources) {
+      this.parserAdapter.setLanguageName(source.languageName)
+      let tree: TreeSitterTree
+      try {
+        tree = this.parse(source)
+      } catch (err) {
+        err.message += `\nuri: ${source.uri}`
+        this.errors.push(err)
+        continue
+      }
+
+      const language = getLanguage(source.languageName)
+      const queryStrings = getQueryStrings(language)
+      for (const queryString of queryStrings) {
+        const query = this.parserAdapter.query(queryString)
+        const matches = query.matches(tree.rootNode)
+        for (const match of matches) {
+          sourceMatches.push({ source, match })
+        }
+      }
+    }
+    return sourceMatches
+  }
+
+  getErrors(): readonly Error[] {
+    return this.errors
+  }
+
+  private parse(source: Source): TreeSitterTree {
+    let tree: TreeSitterTree | undefined = this.treeByContent.get(source)
+    if (!tree) {
+      this.treeByContent.set(source, (tree = this.parserAdapter.parser.parse(source.content)))
+    }
+    return tree
+  }
+}

--- a/src/language/csharpLanguage.ts
+++ b/src/language/csharpLanguage.ts
@@ -1,9 +1,6 @@
 import { Language } from './types.js'
 
 export const csharpLanguage: Language = {
-  // Empty array because SpecFlow does not support Cucumber Expressions out of the box
-  // They are supported via CucumberExpressions.SpecFlow - see https://github.com/cucumber/language-service/pull/29#discussion_r858319308
-  // so we could add support for this in the future
   defineParameterTypeQueries: [
     // [StepArgumentTransformation(@"blabla")]
     `

--- a/src/language/csharpLanguage.ts
+++ b/src/language/csharpLanguage.ts
@@ -75,20 +75,16 @@ export const csharpLanguage: Language = {
     }
     const match = expression.match(/^@"(.*)"$/)
     if (!match) throw new Error(`Could not match ${expression}`)
-    const regExp = unescapeRegExp(match[1])
-    return regExp
+    return new RegExp(unescapeString(match[1]))
   },
-  convertStepDefinitionExpression(s) {
-    const regexParamMatch = s.match(/(\([^)]+[*+]\)|\.\*)/)
-    const regexExpressionMatch = s.match(/^@"(\^.*\$)"$/)
-
-    if (regexExpressionMatch || regexParamMatch) {
-      // For regex step definitions, the string always needs to be verbatim_string_literal (i.e. Prefixed with an '@')
-      return new RegExp(s.substring(2, s.length - 1))
+  convertStepDefinitionExpression(expression) {
+    const match = expression.match(/^(@)?"(.*)"$/)
+    if (!match) throw new Error(`Could not match ${expression}`)
+    if (match[1] === '@') {
+      return new RegExp(unescapeString(match[2]))
+    } else {
+      return unescapeString(match[2])
     }
-
-    const exprStart = s.startsWith('@') ? 2 : 1
-    return s.substring(exprStart, s.length - 1)
   },
 
   snippetParameters: {
@@ -116,6 +112,6 @@ export const csharpLanguage: Language = {
 }
 
 // C# escapes \ as \\. Turn \\ back to \.
-function unescapeRegExp(regexp: string): RegExp {
-  return new RegExp(regexp.replace(/\\\\/g, '\\'))
+function unescapeString(s: string): string {
+  return s.replace(/\\\\/g, '\\')
 }

--- a/src/language/csharpLanguage.ts
+++ b/src/language/csharpLanguage.ts
@@ -5,33 +5,36 @@ export const csharpLanguage: Language = {
   // They are supported via CucumberExpressions.SpecFlow - see https://github.com/cucumber/language-service/pull/29#discussion_r858319308
   // so we could add support for this in the future
   defineParameterTypeQueries: [
+    // [StepArgumentTransformation(@"blabla")]
     `
-(method_declaration 
-  (attribute_list
-    (attribute
-      name: (identifier) @attribute-name
-      (attribute_argument_list
-        (attribute_argument
-          (verbatim_string_literal) @expression
+    (method_declaration
+      (attribute_list
+        (attribute
+          name: (identifier) @attribute-name
+          (attribute_argument_list
+            (attribute_argument
+              (verbatim_string_literal) @expression
+            )
+          )
         )
       )
-    )
-  )
-  type: (identifier) @name
-  (#eq? @attribute-name "StepArgumentTransformation")
-) @root
-`,
-    //     `
-    // (method_declaration
-    //   (attribute_list
-    //     (attribute
-    //       name: (identifier) @attribute-name
-    //     )
-    //   )
-    //   type: (identifier) @name
-    //   (#eq? @attribute-name "StepArgumentTransformation")
-    // ) @root
-    //     `,
+      type: (identifier) @name
+      (#eq? @attribute-name "StepArgumentTransformation")
+    ) @root
+    `,
+    // [StepArgumentTransformation]
+    `
+    (method_declaration
+      (attribute_list
+        (attribute
+          name: (identifier) @attribute-name
+          .
+        )
+      )
+      type: (identifier) @name
+      (#eq? @attribute-name "StepArgumentTransformation")
+    ) @root
+        `,
   ],
   defineStepDefinitionQueries: [
     `
@@ -65,9 +68,13 @@ export const csharpLanguage: Language = {
 ) @root
 `,
   ],
-  convertParameterTypeExpression(s) {
-    const match = s.match(/^@"(.*)"$/)
-    if (!match) throw new Error(`Could not match ${s}`)
+  convertParameterTypeExpression(expression) {
+    if (expression === null) {
+      // https://github.com/gasparnagy/CucumberExpressions.SpecFlow/blob/a2354d2175f5c632c9ae4a421510f314efce4111/CucumberExpressions.SpecFlow.SpecFlowPlugin/Expressions/CucumberExpressionParameterType.cs#L10
+      return /.*/
+    }
+    const match = expression.match(/^@"(.*)"$/)
+    if (!match) throw new Error(`Could not match ${expression}`)
     const regExp = unescapeRegExp(match[1])
     return regExp
   },

--- a/src/language/csharpLanguage.ts
+++ b/src/language/csharpLanguage.ts
@@ -4,7 +4,35 @@ export const csharpLanguage: Language = {
   // Empty array because SpecFlow does not support Cucumber Expressions out of the box
   // They are supported via CucumberExpressions.SpecFlow - see https://github.com/cucumber/language-service/pull/29#discussion_r858319308
   // so we could add support for this in the future
-  defineParameterTypeQueries: [],
+  defineParameterTypeQueries: [
+    `
+(method_declaration 
+  (attribute_list
+    (attribute
+      name: (identifier) @attribute-name
+      (attribute_argument_list
+        (attribute_argument
+          (verbatim_string_literal) @expression
+        )
+      )
+    )
+  )
+  type: (identifier) @name
+  (#eq? @attribute-name "StepArgumentTransformation")
+) @root
+`,
+    //     `
+    // (method_declaration
+    //   (attribute_list
+    //     (attribute
+    //       name: (identifier) @attribute-name
+    //     )
+    //   )
+    //   type: (identifier) @name
+    //   (#eq? @attribute-name "StepArgumentTransformation")
+    // ) @root
+    //     `,
+  ],
   defineStepDefinitionQueries: [
     `
 (method_declaration
@@ -37,9 +65,11 @@ export const csharpLanguage: Language = {
 ) @root
 `,
   ],
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   convertParameterTypeExpression(s) {
-    throw new Error('Unsupported operation')
+    const match = s.match(/^@"(.*)"$/)
+    if (!match) throw new Error(`Could not match ${s}`)
+    const regExp = unescapeRegExp(match[1])
+    return regExp
   },
   convertStepDefinitionExpression(s) {
     const regexParamMatch = s.match(/(\([^)]+[*+]\)|\.\*)/)
@@ -76,4 +106,9 @@ export const csharpLanguage: Language = {
         // {{ blurb }}
     }
 `,
+}
+
+// C# escapes \ as \\. Turn \\ back to \.
+function unescapeRegExp(regexp: string): RegExp {
+  return new RegExp(regexp.replace(/\\\\/g, '\\'))
 }

--- a/src/language/helpers.ts
+++ b/src/language/helpers.ts
@@ -1,0 +1,81 @@
+import { ParameterType, RegExps } from '@cucumber/cucumber-expressions'
+import { DocumentUri, LocationLink, Range } from 'vscode-languageserver-types'
+
+import { getLanguage } from './languages.js'
+import { SourceMatch } from './SourceAnalyzer.js'
+import { Link, ParameterTypeLink, TreeSitterQueryMatch, TreeSitterSyntaxNode } from './types'
+
+export function stripQuotes(s: string): string {
+  const match = s.match(/^['"](.*)['"]$/)
+  if (!match) return s
+  return match[1]
+}
+
+export function syntaxNode(
+  match: TreeSitterQueryMatch,
+  name: string
+): TreeSitterSyntaxNode | undefined {
+  return match.captures.find((c) => c.name === name)?.node
+}
+
+export function makeParameterType(name: string, regexps: RegExps) {
+  return new ParameterType(name, regexps, Object, (arg) => arg, true, false)
+}
+
+export function sortLinks<L extends Link>(links: L[]): readonly L[] {
+  return links.sort((a, b) => {
+    const pathComparison = a.locationLink.targetUri.localeCompare(b.locationLink.targetUri)
+    if (pathComparison !== 0) return pathComparison
+    return a.locationLink.targetRange.start.line - b.locationLink.targetRange.start.line
+  })
+}
+
+export function createLocationLink(
+  rootNode: TreeSitterSyntaxNode,
+  selectionNode: TreeSitterSyntaxNode,
+  targetUri: DocumentUri
+) {
+  const targetRange: Range = Range.create(
+    rootNode.startPosition.row,
+    rootNode.startPosition.column,
+    rootNode.endPosition.row,
+    rootNode.endPosition.column
+  )
+  const targetSelectionRange: Range = Range.create(
+    selectionNode.startPosition.row,
+    selectionNode.startPosition.column,
+    selectionNode.endPosition.row,
+    selectionNode.endPosition.column
+  )
+  const locationLink: LocationLink = {
+    targetRange,
+    targetSelectionRange,
+    targetUri,
+  }
+  return locationLink
+}
+
+export function buildParameterTypeLinksFromMatches(
+  parameterTypeMatches: readonly SourceMatch[]
+): readonly ParameterTypeLink[] {
+  const parameterTypeLinks: ParameterTypeLink[] = []
+  for (const { source, match } of parameterTypeMatches) {
+    const nameNode = syntaxNode(match, 'name')
+    const expressionNode = syntaxNode(match, 'expression')
+    const rootNode = syntaxNode(match, 'root')
+    if (nameNode && rootNode) {
+      // SpecFlow allows definition of parameter types (StepArgumentTransformation) without specifying an expression
+      // See https://github.com/gasparnagy/CucumberExpressions.SpecFlow/blob/a2354d2175f5c632c9ae4a421510f314efce4111/CucumberExpressions.SpecFlow.SpecFlowPlugin/Expressions/UserDefinedCucumberExpressionParameterTypeTransformation.cs#L25-L27
+      const parameterTypeExpression = expressionNode ? expressionNode.text : null
+      const language = getLanguage(source.languageName)
+      const parameterType = makeParameterType(
+        stripQuotes(nameNode.text),
+        language.convertParameterTypeExpression(parameterTypeExpression)
+      )
+      const selectionNode = expressionNode || nameNode
+      const locationLink = createLocationLink(rootNode, selectionNode, source.uri)
+      parameterTypeLinks.push({ parameterType, locationLink })
+    }
+  }
+  return parameterTypeLinks
+}

--- a/src/language/javaLanguage.ts
+++ b/src/language/javaLanguage.ts
@@ -73,13 +73,14 @@ export const javaLanguage: Language = {
 `,
   ],
 
-  convertParameterTypeExpression(s: string): RegExp {
-    const match = s.match(/^"(.*)"$/)
-    if (!match) throw new Error(`Could not match ${s}`)
+  convertParameterTypeExpression(expression) {
+    if (expression === null) throw new Error('expression cannot be null')
+    const match = expression.match(/^"(.*)"$/)
+    if (!match) throw new Error(`Could not match ${expression}`)
     return unescapeRegExp(match[1])
   },
 
-  convertStepDefinitionExpression(s: string): string | RegExp {
+  convertStepDefinitionExpression(s) {
     const match = s.match(/^"(\^.*\$)"$/)
     if (match) {
       const regExp = unescapeRegExp(match[1])

--- a/src/language/javaLanguage.ts
+++ b/src/language/javaLanguage.ts
@@ -77,16 +77,15 @@ export const javaLanguage: Language = {
     if (expression === null) throw new Error('expression cannot be null')
     const match = expression.match(/^"(.*)"$/)
     if (!match) throw new Error(`Could not match ${expression}`)
-    return unescapeRegExp(match[1])
+    return new RegExp(unescapeString(match[1]))
   },
 
-  convertStepDefinitionExpression(s) {
-    const match = s.match(/^"(\^.*\$)"$/)
+  convertStepDefinitionExpression(expression) {
+    const match = expression.match(/^"(\^.*\$)"$/)
     if (match) {
-      const regExp = unescapeRegExp(match[1])
-      return new RegExp(regExp)
+      return new RegExp(unescapeString(match[1]))
     }
-    return s.substring(1, s.length - 1)
+    return unescapeString(expression.substring(1, expression.length - 1))
   },
 
   snippetParameters: {
@@ -111,6 +110,6 @@ export const javaLanguage: Language = {
 }
 
 // Java escapes \ as \\. Turn \\ back to \.
-function unescapeRegExp(regexp: string): RegExp {
-  return new RegExp(regexp.replace(/\\\\/g, '\\'))
+function unescapeString(s: string): string {
+  return s.replace(/\\\\/g, '\\')
 }

--- a/src/language/javaLanguage.ts
+++ b/src/language/javaLanguage.ts
@@ -1,3 +1,4 @@
+import { buildParameterTypeLinksFromMatches } from './helpers.js'
 import { Language } from './types.js'
 
 export const javaLanguage: Language = {
@@ -87,7 +88,9 @@ export const javaLanguage: Language = {
     }
     return unescapeString(expression.substring(1, expression.length - 1))
   },
-
+  buildParameterTypeLinks(matches) {
+    return buildParameterTypeLinksFromMatches(matches)
+  },
   snippetParameters: {
     int: { type: 'int', name: 'i' },
     float: { type: 'float', name: 'f' },

--- a/src/language/phpLanguage.ts
+++ b/src/language/phpLanguage.ts
@@ -1,3 +1,4 @@
+import { buildParameterTypeLinksFromMatches } from './helpers.js'
 import { Language } from './types.js'
 
 export const phpLanguage: Language = {
@@ -20,6 +21,9 @@ export const phpLanguage: Language = {
     const match = expression.match(/^(\/\*\*[\s*]*)([\s\S]*)(\n[\s]*\*\/)/)
     if (!match) throw new Error(`Could not match ${expression}`)
     return new RegExp(match[2].replace(/@(Given |When |Then )/, '').trim())
+  },
+  buildParameterTypeLinks(matches) {
+    return buildParameterTypeLinksFromMatches(matches)
   },
 
   snippetParameters: {

--- a/src/language/phpLanguage.ts
+++ b/src/language/phpLanguage.ts
@@ -12,13 +12,13 @@ export const phpLanguage: Language = {
 `,
   ],
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  convertParameterTypeExpression(s: string): RegExp {
+  convertParameterTypeExpression(expression) {
     throw new Error('Unsupported operation')
   },
-  convertStepDefinitionExpression(s: string): string | RegExp {
+  convertStepDefinitionExpression(expression) {
     // match multiline comment
-    const match = s.match(/^(\/\*\*[\s*]*)([\s\S]*)(\n[\s]*\*\/)/)
-    if (!match) throw new Error(`Could not match ${s}`)
+    const match = expression.match(/^(\/\*\*[\s*]*)([\s\S]*)(\n[\s]*\*\/)/)
+    if (!match) throw new Error(`Could not match ${expression}`)
     return new RegExp(match[2].replace(/@(Given |When |Then )/, '').trim())
   },
 

--- a/src/language/rubyLanguage.ts
+++ b/src/language/rubyLanguage.ts
@@ -50,12 +50,13 @@ export const rubyLanguage: Language = {
 `,
   ],
 
-  convertParameterTypeExpression(expression: string) {
+  convertParameterTypeExpression(expression) {
+    if (expression === null) throw new Error('expression cannot be null')
     return toStringOrRegExp(expression)
   },
 
-  convertStepDefinitionExpression(s: string) {
-    return toStringOrRegExp(s)
+  convertStepDefinitionExpression(expression) {
+    return toStringOrRegExp(expression)
   },
 
   snippetParameters: {

--- a/src/language/rubyLanguage.ts
+++ b/src/language/rubyLanguage.ts
@@ -1,3 +1,4 @@
+import { buildParameterTypeLinksFromMatches } from './helpers.js'
 import { Language } from './types.js'
 
 export const rubyLanguage: Language = {
@@ -57,6 +58,9 @@ export const rubyLanguage: Language = {
 
   convertStepDefinitionExpression(expression) {
     return toStringOrRegExp(expression)
+  },
+  buildParameterTypeLinks(matches) {
+    return buildParameterTypeLinksFromMatches(matches)
   },
 
   snippetParameters: {

--- a/src/language/types.ts
+++ b/src/language/types.ts
@@ -32,8 +32,8 @@ export type ParameterTypeMeta = { name: string; regexp: string }
 export const LanguageNames = ['java', 'typescript', 'c_sharp', 'php', 'ruby'] as const
 export type LanguageName = typeof LanguageNames[number]
 
-export type Source<L> = {
-  readonly languageName: L
+export type Source = {
+  readonly languageName: LanguageName
   readonly uri: DocumentUri
   readonly content: string
 }

--- a/src/language/types.ts
+++ b/src/language/types.ts
@@ -39,8 +39,8 @@ export type ParameterTypeMeta = { name: string; regexp: string }
 export const LanguageNames = ['java', 'typescript', 'c_sharp', 'php', 'ruby'] as const
 export type LanguageName = typeof LanguageNames[number]
 
-export type Source = {
-  readonly languageName: LanguageName
+export type Source<L> = {
+  readonly languageName: L
   readonly uri: DocumentUri
   readonly content: string
 }

--- a/src/language/types.ts
+++ b/src/language/types.ts
@@ -1,5 +1,12 @@
-import { Expression, ParameterType, ParameterTypeRegistry } from '@cucumber/cucumber-expressions'
+import {
+  Expression,
+  ParameterType,
+  ParameterTypeRegistry,
+  StringOrRegExp,
+} from '@cucumber/cucumber-expressions'
 import { DocumentUri, LocationLink } from 'vscode-languageserver-types'
+
+import { SourceMatch } from './SourceAnalyzer'
 
 export type ParameterTypeName =
   | 'int'
@@ -43,8 +50,9 @@ export type Language = {
   readonly defineParameterTypeQueries: readonly string[]
   readonly defineStepDefinitionQueries: readonly string[]
   readonly snippetParameters: SnippetParameters
-  convertStepDefinitionExpression(expression: string): string | RegExp
-  convertParameterTypeExpression(expression: string | null): string | RegExp
+  convertStepDefinitionExpression(expression: string): StringOrRegExp
+  convertParameterTypeExpression(expression: string | null): StringOrRegExp
+  buildParameterTypeLinks(matches: readonly SourceMatch[]): readonly ParameterTypeLink[]
 }
 
 export type ExpressionBuilderResult = {

--- a/src/language/types.ts
+++ b/src/language/types.ts
@@ -44,7 +44,7 @@ export type Language = {
   readonly defineStepDefinitionQueries: readonly string[]
   readonly snippetParameters: SnippetParameters
   convertStepDefinitionExpression(expression: string): string | RegExp
-  convertParameterTypeExpression(expression: string): string | RegExp
+  convertParameterTypeExpression(expression: string | null): string | RegExp
 }
 
 export type ExpressionBuilderResult = {

--- a/src/language/typescriptLanguage.ts
+++ b/src/language/typescriptLanguage.ts
@@ -1,3 +1,4 @@
+import { buildParameterTypeLinksFromMatches } from './helpers.js'
 import { Language } from './types.js'
 
 export const typescriptLanguage: Language = {
@@ -60,7 +61,9 @@ export const typescriptLanguage: Language = {
   convertStepDefinitionExpression(expression) {
     return toStringOrRegExp(expression)
   },
-
+  buildParameterTypeLinks(matches) {
+    return buildParameterTypeLinksFromMatches(matches)
+  },
   snippetParameters: {
     int: { type: 'number' },
     float: { type: 'number' },

--- a/src/language/typescriptLanguage.ts
+++ b/src/language/typescriptLanguage.ts
@@ -52,12 +52,13 @@ export const typescriptLanguage: Language = {
 `,
   ],
 
-  convertParameterTypeExpression(s: string) {
-    return toStringOrRegExp(s)
+  convertParameterTypeExpression(expression) {
+    if (expression === null) throw new Error('expression cannot be null')
+    return toStringOrRegExp(expression)
   },
 
-  convertStepDefinitionExpression(s: string) {
-    return toStringOrRegExp(s)
+  convertStepDefinitionExpression(expression) {
+    return toStringOrRegExp(expression)
   },
 
   snippetParameters: {

--- a/test/language/ExpressionBuilder.test.ts
+++ b/test/language/ExpressionBuilder.test.ts
@@ -23,7 +23,7 @@ function defineContract(makeParserAdapter: () => ParserAdapter) {
     const languageName = basename(dir) as LanguageName
 
     if (languageName === 'c_sharp') {
-      it(`builds parameter type without expression from ${languageName} source`, async () => {
+      it(`builds parameter type from [StepArgumentTransformation] without expression`, async () => {
         const sources = await loadSources(dir, languageName)
         const result = expressionBuilder.build(sources, [{ regexp: '.*', name: 'int' }])
 
@@ -31,6 +31,16 @@ function defineContract(makeParserAdapter: () => ParserAdapter) {
           (l) => l.parameterType.name === 'WithoutExpression'
         )?.parameterType?.regexpStrings
         assert.deepStrictEqual(regexpStrings, ['.*'])
+      })
+
+      it(`builds parameter type from multiple [StepArgumentTransformation] with the same return type`, async () => {
+        const sources = await loadSources(dir, languageName)
+        const result = expressionBuilder.build(sources, [{ regexp: '.*', name: 'int' }])
+
+        const regexpStrings = result.parameterTypeLinks.find(
+          (l) => l.parameterType.name === 'DateTime'
+        )?.parameterType?.regexpStrings
+        assert.deepStrictEqual(regexpStrings, ['today', 'tomorrow', '(.*) days later'])
       })
     }
 

--- a/test/language/ExpressionBuilder.test.ts
+++ b/test/language/ExpressionBuilder.test.ts
@@ -86,10 +86,7 @@ Please register a ParameterType for 'undefined-parameter'`,
   }
 }
 
-async function loadSources(
-  dir: string,
-  languageName: LanguageName
-): Promise<Source<LanguageName>[]> {
+async function loadSources(dir: string, languageName: LanguageName): Promise<Source[]> {
   return Promise.all(
     glob.sync(`${dir}/**/*`).map((path) => {
       return readFile(path, 'utf-8').then((content) => ({

--- a/test/language/ExpressionBuilder.test.ts
+++ b/test/language/ExpressionBuilder.test.ts
@@ -96,7 +96,10 @@ Please register a ParameterType for 'undefined-parameter'`,
   }
 }
 
-async function loadSources(dir: string, languageName: LanguageName): Promise<Source[]> {
+async function loadSources(
+  dir: string,
+  languageName: LanguageName
+): Promise<Source<LanguageName>[]> {
   return Promise.all(
     glob.sync(`${dir}/**/*`).map((path) => {
       return readFile(path, 'utf-8').then((content) => ({

--- a/test/language/testdata/c_sharp/ParameterTypes.cs
+++ b/test/language/testdata/c_sharp/ParameterTypes.cs
@@ -34,44 +34,44 @@ namespace BddWithSpecFlow.GeekPizza.Specs.Support
 
         // DATE
 
-        // [StepArgumentTransformation("today")]
-        // public DateTime ConvertToday()
-        // {
-        //     return DateTime.Today;
-        // }
+        [StepArgumentTransformation("today")]
+        public DateTime ConvertToday()
+        {
+            return DateTime.Today;
+        }
 
-        // [StepArgumentTransformation("tomorrow")]
-        // public DateTime ConvertTomorrow()
-        // {
-        //     return DateTime.Today.AddDays(1);
-        // }
+        [StepArgumentTransformation("tomorrow")]
+        public DateTime ConvertTomorrow()
+        {
+            return DateTime.Today.AddDays(1);
+        }
 
-        // [StepArgumentTransformation("(.*) days later")]
-        // public DateTime ConvertDaysLater(int days)
-        // {
-        //     return DateTime.Today.AddDays(days);
-        // }
+        [StepArgumentTransformation("(.*) days later")]
+        public DateTime ConvertDaysLater(int days)
+        {
+            return DateTime.Today.AddDays(days);
+        }
 
         // TIME
 
-        // [StepArgumentTransformation(@"(\d+):(\d+)")]
-        // public TimeSpan ConvertTimeSpan(int hours, int minutes)
-        // {
-        //     return new TimeSpan(hours, minutes, 0);
-        // }
+        [StepArgumentTransformation(@"(\d+):(\d+)")]
+        public TimeSpan ConvertTimeSpan(int hours, int minutes)
+        {
+            return new TimeSpan(hours, minutes, 0);
+        }
 
-        // [StepArgumentTransformation("noon")]
-        // public TimeSpan ConvertNoon()
-        // {
-        //     return TimeSpan.FromHours(12);
-        // }
+        [StepArgumentTransformation("noon")]
+        public TimeSpan ConvertNoon()
+        {
+            return TimeSpan.FromHours(12);
+        }
 
-        // [StepArgumentTransformation(@"(\d+)(am|pm)")]
-        // public TimeSpan ConvertTimeSpanAmPm(int hours, string ampm)
-        // {
-        //     if (ampm == "pm" && hours < 12) hours += 12;
-        //     if (ampm == "am" && hours == 12) hours -= 12;
-        //     return new TimeSpan(hours, 0, 0);
-        // }
+        [StepArgumentTransformation(@"(\d+)(am|pm)")]
+        public TimeSpan ConvertTimeSpanAmPm(int hours, string ampm)
+        {
+            if (ampm == "pm" && hours < 12) hours += 12;
+            if (ampm == "am" && hours == 12) hours -= 12;
+            return new TimeSpan(hours, 0, 0);
+        }
     }
 }

--- a/test/language/testdata/c_sharp/ParameterTypes.cs
+++ b/test/language/testdata/c_sharp/ParameterTypes.cs
@@ -1,29 +1,77 @@
+using System;
+using BddWithSpecFlow.GeekPizza.Web.DataAccess;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 using TechTalk.SpecFlow;
-using uuid = System.String
-using date = System.DateOnly
+using uuid = System.String;
+using date = System.DateOnly;
 
-namespace StepDefinitions
+namespace BddWithSpecFlow.GeekPizza.Specs.Support
 {
-	[Binding]
-	public class ParameterTypes
-	{
+    [Binding]
+    public class Conversions
+    {
+        // Define the {uuid} and {date} parameter types required for the generic tests
+
         [StepArgumentTransformation(@"[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}")]
         public uuid ConvertUuid(string s)
         {
           return s
         }
 
-        [StepArgumentTransformation(@"\\d{4}-\\d{2}-\\d{2}")]
+        [StepArgumentTransformation(@"\d{4}-\d{2}-\d{2}")]
         public date ConvertDate(string s)
         {
           return s
         }
 
-        // Additional parameter type without an expression
+        // Define some additional parameter types for c_sharp specific tests. 
         [StepArgumentTransformation]
-        public WithoutExpression ConvertWithoutExpression(string s)
-        {
-          return s
+        public WithoutExpression ConvertWithoutExpression(string s) {
+            return new WithoutExpression(s)
         }
-	}
+
+        // The rest is copied from https://github.com/specsolutions/202200607-EuroSTAR-AutomationWithSpecFlow/blob/main/Solutions/D2/BddWithSpecFlow.GeekPizza.API.Specs/Support/Conversions.cs
+
+        // DATE
+
+        // [StepArgumentTransformation("today")]
+        // public DateTime ConvertToday()
+        // {
+        //     return DateTime.Today;
+        // }
+
+        // [StepArgumentTransformation("tomorrow")]
+        // public DateTime ConvertTomorrow()
+        // {
+        //     return DateTime.Today.AddDays(1);
+        // }
+
+        // [StepArgumentTransformation("(.*) days later")]
+        // public DateTime ConvertDaysLater(int days)
+        // {
+        //     return DateTime.Today.AddDays(days);
+        // }
+
+        // TIME
+
+        // [StepArgumentTransformation(@"(\d+):(\d+)")]
+        // public TimeSpan ConvertTimeSpan(int hours, int minutes)
+        // {
+        //     return new TimeSpan(hours, minutes, 0);
+        // }
+
+        // [StepArgumentTransformation("noon")]
+        // public TimeSpan ConvertNoon()
+        // {
+        //     return TimeSpan.FromHours(12);
+        // }
+
+        // [StepArgumentTransformation(@"(\d+)(am|pm)")]
+        // public TimeSpan ConvertTimeSpanAmPm(int hours, string ampm)
+        // {
+        //     if (ampm == "pm" && hours < 12) hours += 12;
+        //     if (ampm == "am" && hours == 12) hours -= 12;
+        //     return new TimeSpan(hours, 0, 0);
+        // }
+    }
 }

--- a/test/language/testdata/c_sharp/ParameterTypes.cs
+++ b/test/language/testdata/c_sharp/ParameterTypes.cs
@@ -1,0 +1,22 @@
+using TechTalk.SpecFlow;
+using uuid = System.String
+using date = System.DateOnly
+
+namespace StepDefinitions
+{
+	[Binding]
+	public class ParameterTypes
+	{
+        [StepArgumentTransformation(@"[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}")]
+        public uuid ConvertUuid(string s)
+        {
+          return s
+        }
+
+        [StepArgumentTransformation(@"\\d{4}-\\d{2}-\\d{2}")]
+        public date ConvertDate(string s)
+        {
+          return s
+        }
+	}
+}

--- a/test/language/testdata/c_sharp/ParameterTypes.cs
+++ b/test/language/testdata/c_sharp/ParameterTypes.cs
@@ -18,5 +18,12 @@ namespace StepDefinitions
         {
           return s
         }
+
+        // Additional parameter type without an expression
+        [StepArgumentTransformation]
+        public WithoutExpression ConvertWithoutExpression(string s)
+        {
+          return s
+        }
 	}
 }

--- a/test/language/testdata/c_sharp/StepDefinitions.cs
+++ b/test/language/testdata/c_sharp/StepDefinitions.cs
@@ -3,25 +3,25 @@ using TechTalk.SpecFlow;
 namespace StepDefinitions
 {
 	[Binding]
-	public class BowlingSteps
+	public class Steps
 	{
+		[Given("a {uuid}")]
+		public void AUniqueID(string uuid)
+		{
+		}
+
+		[Given("a {date}")]
+		public void ADate(Date date)
+		{
+		}
+
 		[Given(@"^a regexp$")]
-		public void ARegexp() 
+		public void ARegexp()
 		{
 		}
 
-		[When("a {uuid}")]
-		public void AUniqueID(string uuid) 
-		{
-		}
-
-		[Then("a {date}")]
-		public void ADate(Date date) 
-		{
-		}
-
-		[Then("an {undefined-parameter}")]
-		public void AnUndefinedParameter(Date date) 
+		[Given("an {undefined-parameter}")]
+		public void AnUndefinedParameter(Date date)
 		{
 		}
 	}

--- a/test/service/snippet/stepDefinitionSnippet.test.ts
+++ b/test/service/snippet/stepDefinitionSnippet.test.ts
@@ -23,7 +23,7 @@ describe('stepDefinitionSnippet', () => {
       )
 
       const expressionBuilder = new ExpressionBuilder(new NodeParserAdapter())
-      const source: Source<LanguageName> = {
+      const source: Source = {
         uri: 'file:///tmp/test.x',
         languageName,
         content: snippet,

--- a/test/service/snippet/stepDefinitionSnippet.test.ts
+++ b/test/service/snippet/stepDefinitionSnippet.test.ts
@@ -3,7 +3,7 @@ import assert from 'assert'
 
 import { ExpressionBuilder } from '../../../src/language/ExpressionBuilder.js'
 import { getLanguage } from '../../../src/language/languages.js'
-import { LanguageName, LanguageNames, Source } from '../../../src/language/types.js'
+import { LanguageNames, Source } from '../../../src/language/types.js'
 import { stepDefinitionSnippet } from '../../../src/service/snippet/stepDefinitionSnippet.js'
 import { NodeParserAdapter } from '../../../src/tree-sitter-node/NodeParserAdapter.js'
 

--- a/test/service/snippet/stepDefinitionSnippet.test.ts
+++ b/test/service/snippet/stepDefinitionSnippet.test.ts
@@ -3,7 +3,7 @@ import assert from 'assert'
 
 import { ExpressionBuilder } from '../../../src/language/ExpressionBuilder.js'
 import { getLanguage } from '../../../src/language/languages.js'
-import { LanguageNames, Source } from '../../../src/language/types.js'
+import { LanguageName, LanguageNames, Source } from '../../../src/language/types.js'
 import { stepDefinitionSnippet } from '../../../src/service/snippet/stepDefinitionSnippet.js'
 import { NodeParserAdapter } from '../../../src/tree-sitter-node/NodeParserAdapter.js'
 
@@ -23,7 +23,7 @@ describe('stepDefinitionSnippet', () => {
       )
 
       const expressionBuilder = new ExpressionBuilder(new NodeParserAdapter())
-      const source: Source = {
+      const source: Source<LanguageName> = {
         uri: 'file:///tmp/test.x',
         languageName,
         content: snippet,


### PR DESCRIPTION
This supersedes #65 with some additional fixes. Parameter types (`[StepArgumentTransformation]`) are now parsed, allowing Cucumber Expressions with custom parameter types to be compiled.