### PR TITLE
locationLink.targetUri value replaced by URL value instead in order t…

### DIFF
--- a/src/service/getStepDefinitionLocationLinks.ts
+++ b/src/service/getStepDefinitionLocationLinks.ts
@@ -14,6 +14,9 @@ export function getStepDefinitionLocationLinks(
   const locationLinks: LocationLink[] = []
   for (const expressionLink of expressionLinks) {
     if (expressionLink.expression.match(stepRange.stepText)) {
+      // the expressionLink.locationLink.targetUri value is not a valid Uri for Windows
+      // It is treated as a service. We assign a new URL instead. It is valid for Darwin/Linux/Windows
+      expressionLink.locationLink.targetUri = new URL(expressionLink.locationLink.targetUri).href
       const locationLink: LocationLink = {
         ...expressionLink.locationLink,
         originSelectionRange: stepRange.range,


### PR DESCRIPTION
### 🤔 What's changed?

Replaced the targetUri value with a new URL() instead since the original value in windows is treated as a directory instead of a file.

### ⚡️ What's your motivation? 

Fixed the issue to open steps In windows devices.
#70 https://github.com/cucumber/vscode/issues/82 https://github.com/cucumber/vscode/issues/78


### 🏷️ What kind of change is this?

- :bug: Bug fix (non-breaking change which fixes a defect)

### 📋 Checklist:

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)
- [x] I've changed the behavior of the code


----

*This text was originally generated from a [template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates), then edited by hand. [You can modify the template here.](https://github.com/cucumber/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
