### PR TITLE
Support escaped single quote

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 
 ### Fixed
-- Support escaped single quotes ([#66](https://github.com/cucumber/language-service/issues/66))
+- Support escaped single and doublt quotes in TypeScript and Ruby ([#66](https://github.com/cucumber/language-service/issues/66), [#85](https://github.com/cucumber/language-service/pull/85))
 - Highlight `Background` keyword ([#78](https://github.com/cucumber/language-service/pull/78))
 
 ## [0.31.0] - 2022-07-14

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 
 ### Fixed
+- Support escaped single quotes ([#66](https://github.com/cucumber/language-service/issues/66))
 - Highlight `Background` keyword ([#78](https://github.com/cucumber/language-service/pull/78))
 
 ## [0.31.0] - 2022-07-14

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+- Highlight `Background` keyword ([#78](https://github.com/cucumber/language-service/pull/78))
+
 ## [0.31.0] - 2022-07-14
 ### Added
 - Basic Python Support via behave ([#69](https://github.com/cucumber/language-service/pull/69))

--- a/src/language/rubyLanguage.ts
+++ b/src/language/rubyLanguage.ts
@@ -92,5 +92,5 @@ function toStringOrRegExp(s: string): string | RegExp {
 }
 
 function unescapeString(s: string): string {
-  return s.replace(/\\'/g, "'")
+  return s.replace(/\\'/g, "'").replace(/\\"/g, '"')
 }

--- a/src/language/rubyLanguage.ts
+++ b/src/language/rubyLanguage.ts
@@ -87,6 +87,10 @@ end
 function toStringOrRegExp(s: string): string | RegExp {
   const match = s.match(/^([/'"])(.*)([/'"])$/)
   if (!match) throw new Error(`Could not match '${s}'`)
-  if (match[1] === '/' && match[3] === '/') return new RegExp(match[2])
-  return match[2]
+  if (match[1] === '/' && match[3] === '/') return new RegExp(unescapeString(match[2]))
+  return unescapeString(match[2])
+}
+
+function unescapeString(s: string): string {
+  return s.replace(/\\'/g, "'")
 }

--- a/src/language/typescriptLanguage.ts
+++ b/src/language/typescriptLanguage.ts
@@ -93,5 +93,5 @@ function toStringOrRegExp(s: string): string | RegExp {
 }
 
 function unescapeString(s: string): string {
-  return s.replace(/\\'/g, "'")
+  return s.replace(/\\'/g, "'").replace(/\\"/g, '"')
 }

--- a/src/language/typescriptLanguage.ts
+++ b/src/language/typescriptLanguage.ts
@@ -88,6 +88,10 @@ export const typescriptLanguage: Language = {
 function toStringOrRegExp(s: string): string | RegExp {
   const match = s.match(/^([/'"])(.*)([/'"])$/)
   if (!match) throw new Error(`Could not match ${s}`)
-  if (match[1] === '/' && match[3] === '/') return new RegExp(match[2])
-  return match[2]
+  if (match[1] === '/' && match[3] === '/') return new RegExp(unescapeString(match[2]))
+  return unescapeString(match[2])
+}
+
+function unescapeString(s: string): string {
+  return s.replace(/\\'/g, "'")
 }

--- a/test/language/ExpressionBuilder.test.ts
+++ b/test/language/ExpressionBuilder.test.ts
@@ -82,7 +82,12 @@ function defineContract(makeParserAdapter: () => ParserAdapter) {
       )
       const errors = result.errors.map((e) => e.message)
       if (parameterTypeSupport.has(languageName)) {
-        assert.deepStrictEqual(expressions, ['a {uuid}', 'a {date}', /^a regexp$/])
+        assert.deepStrictEqual(expressions, [
+          'a {uuid}',
+          'a {date}',
+          /^a regexp$/,
+          "the bee's knees",
+        ])
         assert.deepStrictEqual(errors, [
           'There is already a parameter type with name int',
           `This Cucumber Expression has a problem at column 4:

--- a/test/language/testdata/c_sharp/StepDefinitions.cs
+++ b/test/language/testdata/c_sharp/StepDefinitions.cs
@@ -24,5 +24,10 @@ namespace StepDefinitions
 		public void AnUndefinedParameter(Date date)
 		{
 		}
+
+		[Given("the bee's knees")]
+		public void TheBeesKnees()
+		{
+		}
 	}
 }

--- a/test/language/testdata/java/StepDefinitions.java
+++ b/test/language/testdata/java/StepDefinitions.java
@@ -14,6 +14,10 @@ public class StepDefinitions {
     }
 
     @Given("an {undefined-parameter}"  )
-    void a_date(Date date) {
+    void an_undefined_parameter(Date date) {
+    }
+
+    @Given("the bee's knees"  )
+    void the_bees_knees(Date date) {
     }
 }

--- a/test/language/testdata/ruby/StepDefinitions.rb
+++ b/test/language/testdata/ruby/StepDefinitions.rb
@@ -9,3 +9,6 @@ end
 
 Given('an {undefined-parameter}') do |date|
 end
+
+Given('the bee\'s knees') do |date|
+end

--- a/test/language/testdata/typescript/StepDefinitions.ts
+++ b/test/language/testdata/typescript/StepDefinitions.ts
@@ -16,3 +16,8 @@ Given(/^a regexp$/, async function () {
 Given('an {undefined-parameter}', async function (date: Date) {
   assert(date)
 })
+
+// eslint-disable-next-line prettier/prettier
+Given("the bee's knees", async function () {
+  assert(true)
+})

--- a/test/language/testdata/typescript/StepDefinitions.ts
+++ b/test/language/testdata/typescript/StepDefinitions.ts
@@ -17,7 +17,6 @@ Given('an {undefined-parameter}', async function (date: Date) {
   assert(date)
 })
 
-// eslint-disable-next-line prettier/prettier
 Given("the bee's knees", async function () {
   assert(true)
 })


### PR DESCRIPTION
### 🤔 What's changed?

Single and double quotes are now correctly escaped in TypeScript and Ruby

### ⚡️ What's your motivation? 

See https://github.com/cucumber/language-service/issues/66

### 🏷️ What kind of change is this?

- :bug: Bug fix (non-breaking change which fixes a defect)
