### PR TITLE
Preserve regexp flags

### DIFF
--- a/src/language/ExpressionBuilder.ts
+++ b/src/language/ExpressionBuilder.ts
@@ -2,18 +2,13 @@ import {
   ExpressionFactory,
   ParameterType,
   ParameterTypeRegistry,
-  RegExps,
-  StringOrRegExp,
 } from '@cucumber/cucumber-expressions'
-import { LocationLink } from 'vscode-languageserver-types'
 
-import { createLocationLink, makeParameterType, sortLinks, syntaxNode } from './helpers.js'
-import { getLanguage } from './languages.js'
-import { SourceAnalyzer, SourceMatch } from './SourceAnalyzer.js'
+import { createLocationLink, makeParameterType, sortLinks } from './helpers.js'
+import { SourceAnalyzer } from './SourceAnalyzer.js'
 import {
   ExpressionBuilderResult,
   ExpressionLink,
-  Language,
   LanguageName,
   ParameterTypeLink,
   ParameterTypeMeta,
@@ -28,7 +23,6 @@ export class ExpressionBuilder {
     sources: readonly Source<LanguageName>[],
     parameterTypes: readonly ParameterTypeMeta[]
   ): ExpressionBuilderResult {
-    const expressionLinks: ExpressionLink[] = []
     const errors: Error[] = []
     const registry = new ParameterTypeRegistry()
     const expressionFactory = new ExpressionFactory(registry)
@@ -47,40 +41,24 @@ export class ExpressionBuilder {
 
     const sourceAnalyser = new SourceAnalyzer(this.parserAdapter, sources)
 
-    const parameterTypeMatches = sourceAnalyser.getSourceMatches(
-      (language: Language) => language.defineParameterTypeQueries
-    )
+    const parameterTypeLinks: ParameterTypeLink[] = []
+    sourceAnalyser.eachParameterTypeLink((parameterTypeLink) => {
+      defineParameterType(parameterTypeLink.parameterType)
+      parameterTypeLinks.push(parameterTypeLink)
+    })
 
-    let parameterTypeLinks: ParameterTypeLink[] = []
-    for (const [, matches] of parameterTypeMatches.entries()) {
-      const links = buildParameterTypeLinksFromMatches(matches)
-      parameterTypeLinks = parameterTypeLinks.concat(links)
-      for (const { parameterType } of links) {
-        defineParameterType(parameterType)
-      }
-    }
-
-    const stepDefinitionMatches = sourceAnalyser.getSourceMatches(
-      (language: Language) => language.defineStepDefinitionQueries
-    )
-
-    for (const [, sourceMatches] of stepDefinitionMatches.entries()) {
-      for (const { source, match } of sourceMatches) {
-        const expressionNode = syntaxNode(match, 'expression')
-        const rootNode = syntaxNode(match, 'root')
-        if (expressionNode && rootNode) {
-          const language = getLanguage(source.languageName)
-          const stepDefinitionExpression = language.toStepDefinitionExpression(expressionNode)
-          try {
-            const expression = expressionFactory.createExpression(stepDefinitionExpression)
-            const locationLink = createLocationLink(rootNode, expressionNode, source.uri)
-            expressionLinks.push({ expression, locationLink })
-          } catch (err) {
-            errors.push(err)
-          }
+    const expressionLinks: ExpressionLink[] = []
+    sourceAnalyser.eachStepDefinitionExpression(
+      (stepDefinitionExpression, rootNode, expressionNode, source) => {
+        try {
+          const expression = expressionFactory.createExpression(stepDefinitionExpression)
+          const locationLink = createLocationLink(rootNode, expressionNode, source.uri)
+          expressionLinks.push({ expression, locationLink })
+        } catch (err) {
+          errors.push(err)
         }
       }
-    }
+    )
 
     return {
       expressionLinks: sortLinks(expressionLinks),
@@ -89,46 +67,4 @@ export class ExpressionBuilder {
       registry,
     }
   }
-}
-
-function buildParameterTypeLinksFromMatches(
-  parameterTypeMatches: readonly SourceMatch[]
-): readonly ParameterTypeLink[] {
-  const parameterTypeLinks: ParameterTypeLink[] = []
-  const propsByName: Record<string, ParameterTypeLinkProps> = {}
-  for (const { source, match } of parameterTypeMatches) {
-    const nameNode = syntaxNode(match, 'name')
-    const rootNode = syntaxNode(match, 'root')
-    const expressionNode = syntaxNode(match, 'expression')
-    if (nameNode && rootNode) {
-      const language = getLanguage(source.languageName)
-
-      const parameterTypeName = language.toParameterTypeName(nameNode)
-      const regExps = language.toParameterTypeRegExps(expressionNode)
-      const selectionNode = expressionNode || nameNode
-      const locationLink = createLocationLink(rootNode, selectionNode, source.uri)
-      const props: ParameterTypeLinkProps = (propsByName[parameterTypeName] = propsByName[
-        parameterTypeName
-      ] || { locationLink, regexpsList: [] })
-      props.regexpsList.push(regExps)
-    }
-  }
-  for (const [name, { regexpsList, locationLink }] of Object.entries(propsByName)) {
-    const regexps: StringOrRegExp[] = regexpsList.reduce<StringOrRegExp[]>((prev, current) => {
-      if (Array.isArray(current)) {
-        return prev.concat(...current)
-      } else {
-        return prev.concat(current)
-      }
-    }, [])
-    const parameterType = makeParameterType(name, regexps)
-    parameterTypeLinks.push({ parameterType, locationLink })
-  }
-
-  return parameterTypeLinks
-}
-
-type ParameterTypeLinkProps = {
-  regexpsList: RegExps[]
-  locationLink: LocationLink
 }

--- a/src/language/helpers.ts
+++ b/src/language/helpers.ts
@@ -59,7 +59,6 @@ export function childrenToString(node: TreeSitterSyntaxNode, stringNodes: NodePr
 }
 
 export const NO_QUOTES: NodePredicate = (child) => child.type !== '"' && child.type !== "'"
-export const NO_SLASHES: NodePredicate = (child) => child.type !== '/'
 
 export function filter(
   node: TreeSitterSyntaxNode,

--- a/src/language/rubyLanguage.ts
+++ b/src/language/rubyLanguage.ts
@@ -115,10 +115,21 @@ function toRegExps(node: TreeSitterSyntaxNode | null): RegExps {
   }
 }
 
-function toStringOrRegExp(node: TreeSitterSyntaxNode): StringOrRegExp {
+export function toStringOrRegExp(node: TreeSitterSyntaxNode): StringOrRegExp {
   switch (node.type) {
-    case 'regex':
-      return new RegExp(unescapeString(childrenToString(node, NO_SLASHES)))
+    case 'regex': {
+      let flags = ''
+      let flag: string
+      const s = node.text
+      for (let i = s.length - 1; (flag = s[i]) !== '/'; i--) {
+        // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions#advanced_searching_with_flags
+        // https://ruby-doc.org/core-3.1.2/doc/regexp_rdoc.html#label-Options
+        if (flag === 'i' || flag == 'o') {
+          flags = `${flags}${flag}`
+        }
+      }
+      return new RegExp(unescapeString(childrenToString(node, NO_SLASHES)), flags)
+    }
     case 'string':
       return unescapeString(childrenToString(node, NO_QUOTES))
     default:

--- a/src/language/rubyLanguage.ts
+++ b/src/language/rubyLanguage.ts
@@ -1,8 +1,8 @@
 import { StringOrRegExp } from '@cucumber/cucumber-expressions'
 import { RegExps } from '@cucumber/cucumber-expressions/dist/cjs/src/ParameterType'
 
-import { childrenToString, filter, NO_QUOTES, NO_SLASHES } from './helpers.js'
-import { Language, TreeSitterSyntaxNode } from './types.js'
+import { childrenToString, filter, NO_QUOTES } from './helpers.js'
+import { Language, NodePredicate, TreeSitterSyntaxNode } from './types.js'
 
 export const rubyLanguage: Language = {
   toParameterTypeName(node) {
@@ -114,6 +114,8 @@ function toRegExps(node: TreeSitterSyntaxNode | null): RegExps {
       throw new Error(`Unexpected type: ${node.type}`)
   }
 }
+
+export const NO_SLASHES: NodePredicate = (child) => child.type !== '/'
 
 export function toStringOrRegExp(node: TreeSitterSyntaxNode): StringOrRegExp {
   switch (node.type) {

--- a/test/language/ExpressionBuilder.test.ts
+++ b/test/language/ExpressionBuilder.test.ts
@@ -15,7 +15,7 @@ const cucumberExpressionsSupport: Set<LanguageName> = new Set(['c_sharp', 'java'
 function defineContract(makeParserAdapter: () => ParserAdapter) {
   let expressionBuilder: ExpressionBuilder
   beforeEach(async () => {
-    const parserAdpater = await makeParserAdapter()
+    const parserAdpater = makeParserAdapter()
     await parserAdpater.init()
     expressionBuilder = new ExpressionBuilder(parserAdpater)
   })

--- a/test/language/rubyLanguage.test.ts
+++ b/test/language/rubyLanguage.test.ts
@@ -1,0 +1,25 @@
+import { StringOrRegExp } from '@cucumber/cucumber-expressions'
+import assert from 'assert'
+
+import { Source } from '../../src'
+import { SourceAnalyzer } from '../../src/language/SourceAnalyzer.js'
+import { WasmParserAdapter } from '../../src/tree-sitter-wasm/WasmParserAdapter.js'
+
+describe('rubyLanguage', () => {
+  it('should preserve regexp flags in step defnitions', async () => {
+    const parserAdapter = new WasmParserAdapter('dist')
+    await parserAdapter.init()
+
+    const source: Source<'ruby'> = {
+      uri: 'hello.rb',
+      languageName: 'ruby',
+      content: `Given(/^a regexp$/) {}`,
+    }
+    const expressions: StringOrRegExp[] = []
+    const sourceAnalyser = new SourceAnalyzer(parserAdapter, [source])
+    sourceAnalyser.eachStepDefinitionExpression((expr) => {
+      expressions.push(expr)
+    })
+    assert.deepStrictEqual(expressions, [/^a regexp$/])
+  })
+})

--- a/test/language/rubyLanguage.test.ts
+++ b/test/language/rubyLanguage.test.ts
@@ -1,25 +1,46 @@
 import { StringOrRegExp } from '@cucumber/cucumber-expressions'
 import assert from 'assert'
 
-import { Source } from '../../src'
+import { toStringOrRegExp } from '../../src/language/rubyLanguage.js'
 import { SourceAnalyzer } from '../../src/language/SourceAnalyzer.js'
+import { Source, TreeSitterSyntaxNode } from '../../src/language/types.js'
 import { WasmParserAdapter } from '../../src/tree-sitter-wasm/WasmParserAdapter.js'
 
 describe('rubyLanguage', () => {
-  it('should preserve regexp flags in step defnitions', async () => {
+  it('should preserve regexp flags in step definitions', async () => {
     const parserAdapter = new WasmParserAdapter('dist')
     await parserAdapter.init()
 
     const source: Source<'ruby'> = {
       uri: 'hello.rb',
       languageName: 'ruby',
-      content: `Given(/^a regexp$/) {}`,
+      content: `Given(/^a regexp$/i) {}`,
     }
     const expressions: StringOrRegExp[] = []
     const sourceAnalyser = new SourceAnalyzer(parserAdapter, [source])
     sourceAnalyser.eachStepDefinitionExpression((expr) => {
       expressions.push(expr)
     })
-    assert.deepStrictEqual(expressions, [/^a regexp$/])
+    assert.deepStrictEqual(expressions, [/^a regexp$/i])
+  })
+
+  it('should preserve', () => {
+    const regex: TreeSitterSyntaxNode = {
+      type: 'regex',
+      text: '/^a regexp$/i',
+      startPosition: { row: 0, column: 6 },
+      endPosition: { row: 0, column: 19 },
+      children: [
+        {
+          type: 'string_content',
+          text: '^a regexp$',
+          startPosition: { row: 0, column: 7 },
+          endPosition: { row: 0, column: 17 },
+          children: [],
+        },
+      ],
+    }
+    const result = toStringOrRegExp(regex)
+    assert.deepStrictEqual(result, /^a regexp$/i)
   })
 })

--- a/test/language/tsxLanguage.test.ts
+++ b/test/language/tsxLanguage.test.ts
@@ -1,26 +1,33 @@
 import assert from 'assert'
 
-import { toStringOrRegExp } from '../../src/language/rubyLanguage.js'
+import { toStringOrRegExp } from '../../src/language/tsxLanguage.js'
 import { TreeSitterSyntaxNode } from '../../src/language/types.js'
 
-describe('rubyLanguage', () => {
+describe('tsxLanguage', () => {
   it('should preserve regexp flags in step definitions', () => {
     const regex: TreeSitterSyntaxNode = {
       type: 'regex',
-      text: '/^a regexp$/i',
+      text: '/^a regexp$/imu',
       startPosition: { row: 0, column: 6 },
-      endPosition: { row: 0, column: 19 },
+      endPosition: { row: 0, column: 21 },
       children: [
         {
-          type: 'string_content',
+          type: 'regex_pattern',
           text: '^a regexp$',
           startPosition: { row: 0, column: 7 },
           endPosition: { row: 0, column: 17 },
           children: [],
         },
+        {
+          type: 'regex_flags',
+          text: 'imu',
+          startPosition: { row: 0, column: 18 },
+          endPosition: { row: 0, column: 21 },
+          children: [],
+        },
       ],
     }
     const result = toStringOrRegExp(regex)
-    assert.deepStrictEqual(result, /^a regexp$/i)
+    assert.deepStrictEqual(result, /^a regexp$/imu)
   })
 })


### PR DESCRIPTION
### 🤔 What's changed?

RegExp flags such as `/^a case insensitive step is invoked$/i` so that Gherkin steps are correctly matched. 

### ⚡️ What's your motivation? 

See https://github.com/cucumber/language-service/issues/91#issuecomment-1242243037

### 🏷️ What kind of change is this?

- :bug: Bug fix (non-breaking change which fixes a defect)

### 📋 Checklist:

<!--- 
This is to help you remember all the little things we often forget to do!

Feel free to delete any tasks that are not relevant, or add new ones.
-->

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)
- [x] I've changed the behaviour of the code
  - [x] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [x] Users should know about my change
  - [ ] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../CHANGELOG.md), linking to this pull request.

----

*This text was originally generated from a [template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates), then edited by hand. [You can modify the template here.](https://github.com/cucumber/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
