### PR TITLE
Recognise tsx template literals without substitutions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 - Add support for [document symbols](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_documentSymbol) ([#98](https://github.com/cucumber/language-service/issues/98), [#106](https://github.com/cucumber/language-service/pull/106))
+- (TypeScript) Add support for template literals without subsitutions. ([#101](https://github.com/cucumber/language-service/issues/101), [#107](https://github.com/cucumber/language-service/pull/107))
 
 ## [1.0.1] - 2022-10-10
 

--- a/src/language/SourceAnalyzer.ts
+++ b/src/language/SourceAnalyzer.ts
@@ -20,6 +20,8 @@ export type SourceMatch = {
   match: TreeSitterQueryMatch
 }
 
+export const NO_EXPRESSION = ''
+
 export class SourceAnalyzer {
   private readonly errors: Error[] = []
   private readonly treeByContent = new Map<Source<LanguageName>, TreeSitterTree>()
@@ -86,7 +88,9 @@ export class SourceAnalyzer {
         if (expressionNode && rootNode) {
           const language = getLanguage(source.languageName)
           const stepDefinitionExpression = language.toStepDefinitionExpression(expressionNode)
-          callback(stepDefinitionExpression, rootNode, expressionNode, source)
+          if (stepDefinitionExpression !== NO_EXPRESSION) {
+            callback(stepDefinitionExpression, rootNode, expressionNode, source)
+          }
         }
       }
     }

--- a/src/language/tsxLanguage.ts
+++ b/src/language/tsxLanguage.ts
@@ -76,6 +76,7 @@ export const tsxLanguage: Language = {
     [
       (string) @expression
       (regex) @expression
+      (template_string) @expression
     ]
   )
   (#match? @function-name "Given|When|Then")
@@ -135,6 +136,8 @@ export function toStringOrRegExp(node: TreeSitterSyntaxNode): StringOrRegExp {
     }
     case 'string':
       return unescapeString(childrenToString(node, NO_QUOTES))
+    case 'template_string':
+      return node.text.slice(1, node.text.length - 1)
     default:
       throw new Error(`Unexpected type: ${node.type}`)
   }

--- a/src/language/tsxLanguage.ts
+++ b/src/language/tsxLanguage.ts
@@ -2,6 +2,7 @@ import { StringOrRegExp } from '@cucumber/cucumber-expressions'
 import { RegExps } from '@cucumber/cucumber-expressions/dist/cjs/src/ParameterType'
 
 import { childrenToString, filter, NO_QUOTES } from './helpers.js'
+import { NO_EXPRESSION } from './SourceAnalyzer.js'
 import { Language, TreeSitterSyntaxNode } from './types.js'
 
 export const tsxLanguage: Language = {
@@ -138,8 +139,8 @@ export function toStringOrRegExp(node: TreeSitterSyntaxNode): StringOrRegExp {
       return unescapeString(childrenToString(node, NO_QUOTES))
     case 'template_string':
       if (node.children.length > 0) {
-        // template literal with substitutions. Can't handle those. Return a regexp that matches nothing.
-        return /$^/
+        // template literal with substitutions. Can't handle those.
+        return NO_EXPRESSION
       }
       return node.text.slice(1, node.text.length - 1)
     default:

--- a/src/language/tsxLanguage.ts
+++ b/src/language/tsxLanguage.ts
@@ -137,6 +137,10 @@ export function toStringOrRegExp(node: TreeSitterSyntaxNode): StringOrRegExp {
     case 'string':
       return unescapeString(childrenToString(node, NO_QUOTES))
     case 'template_string':
+      if (node.children.length > 0) {
+        // template literal with substitutions. Can't handle those. Return a regexp that matches nothing.
+        return /$^/
+      }
       return node.text.slice(1, node.text.length - 1)
     default:
       throw new Error(`Unexpected type: ${node.type}`)

--- a/test/language/tsxLanguage.test.ts
+++ b/test/language/tsxLanguage.test.ts
@@ -42,4 +42,32 @@ describe('tsxLanguage', () => {
     const result = toStringOrRegExp(node)
     assert.deepStrictEqual(result, 'hello there')
   })
+
+  it('should generate nothing from template literals with substitution', () => {
+    const node: TreeSitterSyntaxNode = {
+      type: 'template_string',
+      text: '`hello there`',
+      startPosition: { row: 0, column: 5 },
+      endPosition: { row: 0, column: 21 },
+      children: [
+        {
+          type: 'template_subsitution',
+          text: '${there}',
+          startPosition: { row: 0, column: 12 },
+          endPosition: { row: 0, column: 20 },
+          children: [
+            {
+              type: 'identifier',
+              text: 'there',
+              startPosition: { row: 0, column: 14 },
+              endPosition: { row: 0, column: 19 },
+              children: [],
+            },
+          ],
+        },
+      ],
+    }
+    const result = toStringOrRegExp(node)
+    assert.deepStrictEqual(result, /$^/)
+  })
 })

--- a/test/language/tsxLanguage.test.ts
+++ b/test/language/tsxLanguage.test.ts
@@ -5,7 +5,7 @@ import { TreeSitterSyntaxNode } from '../../src/language/types.js'
 
 describe('tsxLanguage', () => {
   it('should preserve regexp flags in step definitions', () => {
-    const regex: TreeSitterSyntaxNode = {
+    const node: TreeSitterSyntaxNode = {
       type: 'regex',
       text: '/^a regexp$/imu',
       startPosition: { row: 0, column: 6 },
@@ -27,7 +27,19 @@ describe('tsxLanguage', () => {
         },
       ],
     }
-    const result = toStringOrRegExp(regex)
+    const result = toStringOrRegExp(node)
     assert.deepStrictEqual(result, /^a regexp$/imu)
+  })
+
+  it('should generate cucumber expression strings from template literals without substitution', () => {
+    const node: TreeSitterSyntaxNode = {
+      type: 'template_string',
+      text: '`hello there`',
+      startPosition: { row: 0, column: 5 },
+      endPosition: { row: 0, column: 18 },
+      children: [],
+    }
+    const result = toStringOrRegExp(node)
+    assert.deepStrictEqual(result, 'hello there')
   })
 })

--- a/test/language/tsxLanguage.test.ts
+++ b/test/language/tsxLanguage.test.ts
@@ -1,5 +1,6 @@
 import assert from 'assert'
 
+import { NO_EXPRESSION } from '../../src/language/SourceAnalyzer.js'
 import { toStringOrRegExp } from '../../src/language/tsxLanguage.js'
 import { TreeSitterSyntaxNode } from '../../src/language/types.js'
 
@@ -43,7 +44,7 @@ describe('tsxLanguage', () => {
     assert.deepStrictEqual(result, 'hello there')
   })
 
-  it('should generate nothing from template literals with substitution', () => {
+  it('should generate a regexp that matches nothing from template literals with substitution', () => {
     const node: TreeSitterSyntaxNode = {
       type: 'template_string',
       text: '`hello there`',
@@ -68,6 +69,6 @@ describe('tsxLanguage', () => {
       ],
     }
     const result = toStringOrRegExp(node)
-    assert.deepStrictEqual(result, /$^/)
+    assert.deepStrictEqual(result, NO_EXPRESSION)
   })
 })


### PR DESCRIPTION
<!---
Thanks for helping to make Cucumber better! 💖

You can feel free to open a "Draft" status pull request if you're not ready for feedback yet.

Don't worry about getting everything perfect! We're here to help and will coach you through
to getting your pull request ready to merge.

The prompts below are for guidance to help you describe your change in a way that is most 
likely to make sense to other people when they are reviewing it. Still, it's just a guide, 
so feel free to delete anything that doesn't feel appropriate, and add anything additional 
that seems like it would provide useful context. 👏🏻
-->

### 🤔 What's changed?

TypeScript template strings are recognised as strings. 

### ⚡️ What's your motivation? 

Fix #101

### 🏷️ What kind of change is this?

<!--- Delete any options that are not relevant -->

- :zap: New feature (non-breaking change which adds new behaviour)

### ♻️ Anything particular you want feedback on?

<!-- 
Is there anything in this change you're unsure about, or would 
particularly like reviewers to give you feedback on?
-->

### 📋 Checklist:

<!--- 
This is to help you remember all the little things we often forget to do!

Feel free to delete any tasks that are not relevant, or add new ones.
-->

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)
- [x] I've changed the behaviour of the code
  - [x] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [x] Users should know about my change
  - [ ] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../CHANGELOG.md), linking to this pull request.

----

*This text was originally generated from a [template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates), then edited by hand. [You can modify the template here.](https://github.com/cucumber/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
