### PR TITLE
Fix CI by eliminating EOL'd Node 14

### DIFF
--- a/.github/workflows/test-javascript.yml
+++ b/.github/workflows/test-javascript.yml
@@ -15,12 +15,11 @@ jobs:
         os:
           - macos-latest
           - ubuntu-latest
+          - windows-latest
+        # 14.x is broken with @typescript-eslint 6.0
         # 16.12.0 has broken ESM support
         # 17.x cannot install tree-sitter: https://github.com/tree-sitter/tree-sitter/issues/1503
-        node-version: ['14.x', '16.11.x']
-        include:
-          - os: windows-latest
-            node-version: '16.11.x'
+        node-version: ['16.11.x', '18.x']
 
     steps:
       - name: set git core.autocrlf to 'input'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 ### Fixed
 - (Python) There was a bug in how long concatenated strings were handled for multi-line regexes
+- Updated TreeSitter and numerous other dependencies to promote runtime compatibility with Electron 14.
 
 ## [1.4.0] - 2022-12-08
 ### Added


### PR DESCRIPTION
### 🤔 What's changed?

Node 14 no longer works with our development tools i.e. eslint.

### ⚡️ What's your motivation? 

I need green CI so I can release a new version of this package.

### 🏷️ What kind of change is this?

- :bug: Bug fix (non-breaking change which fixes a defect)

### 📋 Checklist:

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)
