### PR TITLE
Python u-string patterns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - (Rust) Line continuation characters in rust step definition patterns ([#179](https://github.com/cucumber/language-service/pull/179))
 - (Python) Unexpected spaces and commas in generated step definitions [#160](https://github.com/cucumber/language-service/issues/160)
 
+### Added
+- (Python) Support for u-strings with step definition patterns ([#173](https://github.com/cucumber/language-service/pull/173))
+
 ## [1.4.1] - 2023-07-16
 ### Fixed
 - (Python) There was a bug in how long concatenated strings were handled for multi-line regexes

--- a/src/language/pythonLanguage.ts
+++ b/src/language/pythonLanguage.ts
@@ -106,9 +106,14 @@ function cleanRegExp(regExpString: string): string {
   }
 }
 export function toStringOrRegExp(step: string): StringOrRegExp {
-  return isRegExp(step.slice(1, -1))
-    ? RegExp(cleanRegExp(step.slice(1, -1).split('?P').join('')))
-    : step.slice(1, -1)
+  // Remove explicit 'u' unicode prefix
+  const isUString = step.startsWith('u')
+  const stepText = isUString ? step.slice(1) : step
+
+  const strippedStepText = stepText.slice(1, -1)
+  return isRegExp(strippedStepText)
+    ? RegExp(cleanRegExp(strippedStepText.split('?P').join('')))
+    : strippedStepText
 }
 export function concatStringLiteral(text: string): string {
   const isFString = text.startsWith('f')

--- a/test/language/pythonLanguage.test.ts
+++ b/test/language/pythonLanguage.test.ts
@@ -13,18 +13,35 @@ describe('pythonLanguage', () => {
   it('should identify normal strings and just return a string', () => {
     const nonregexes = ['"test"']
     nonregexes.forEach(function (nonregex) {
-      assert(toStringOrRegExp(nonregex) == 'test')
+      assert.strictEqual(toStringOrRegExp(nonregex), 'test')
     })
   })
-  it('should properly handle concatanated string', () => {
-    const concatedStrings = [
+  it('should properly handle concatenated string', () => {
+    const concatenatedStrings = [
       '"Airnet Address|Superheat|Gas Pipe Temperature|Liquid Pipe Temperature|EEV Opening|"\\\n        "Return Air Temperature|Room Temperature|Setpoint|Filter|On-Off|Reset Filter Indicator|"\\\n        "Thermostat - LockMode|Thermostat - Lock All|Thermostat - Lock Temperature|Thermostat - Lock On-Off|"\\\n        "Fan Speed|Louver Position|Mode|Group Address|Malfunction Code|Indoor Unit Model Code|"\\\n        "Operation-Stop|Thermostat ON|Capacity Increase|Malfunction Cause|Point_1|Point_2"',
     ]
     const expectedStrings = [
       'Airnet Address|Superheat|Gas Pipe Temperature|Liquid Pipe Temperature|EEV Opening|Return Air Temperature|Room Temperature|Setpoint|Filter|On-Off|Reset Filter Indicator|Thermostat - LockMode|Thermostat - Lock All|Thermostat - Lock Temperature|Thermostat - Lock On-Off|Fan Speed|Louver Position|Mode|Group Address|Malfunction Code|Indoor Unit Model Code|Operation-Stop|Thermostat ON|Capacity Increase|Malfunction Cause|Point_1|Point_2',
     ]
-    const z = concatedStrings.map((x, i) => [x, expectedStrings[i]]) //use map to zip the concat with expected for assertion
+    const z = concatenatedStrings.map((x, i) => [x, expectedStrings[i]]) //use map to zip the concat with expected for assertion
     console.log(concatStringLiteral(expectedStrings[0]))
-    z.forEach((x) => assert(concatStringLiteral(x[0]) == x[1]))
+    z.forEach((x) => assert.strictEqual(concatStringLiteral(x[0]), x[1]))
+  })
+
+  it('should strip explicit unicode string prefix', () => {
+    const cases = [
+      {
+        input: 'u"Explicit unicode string"',
+        expected: 'Explicit unicode string',
+      },
+      {
+        input: 'u"^Explicit regex unicode string$"',
+        expected: '^Explicit regex unicode string$',
+      },
+    ]
+
+    cases.forEach(({ input, expected }) => {
+      assert.strictEqual(toStringOrRegExp(input), expected)
+    })
   })
 })


### PR DESCRIPTION
### 🤔 What's changed?

Introduced support for u-strings (explicit unicode strings e.g. `u""`) for Python step definitions.

### ⚡️ What's your motivation? 

Resolves cucumber/vscode#173, allowing step definition patterns written with Python u-strings.

```python
@given(u"I have 58 cukes in my belly")
def step_impl(context):
    ...
```

Although not required in Python 3, they are usable and are suggested in missing step definitions for Behave due to Python 2 compatibility.

Developer experience has been improved for Python unit tests by changing asserts to `assert.strictEqual`, which shows exact match failures in strings - so that they can be fixed - compared to simply stating condition was not True.

### 🏷️ What kind of change is this?

- :zap: New feature (non-breaking change which adds new behaviour)

### 📋 Checklist:

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)
- [x] I've changed the behaviour of the code
  - [x] I have added/updated tests to cover my changes.
- [x] Users should know about my change
  - [x] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request.