### PR TITLE
r# strings in rust

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Fixed
+- (Rust) Support for r# raw strings with step definition patterns ([#176](https://github.com/cucumber/language-service/pull/176))
 
 ## [1.4.1] - 2023-07-16
 ### Fixed

--- a/src/language/rustLanguage.ts
+++ b/src/language/rustLanguage.ts
@@ -109,13 +109,13 @@ fn {{ #lowercase }}{{ #underscore }}{{ expression }}{{ /underscore }}{{ /lowerca
 `,
 }
 
-function stringLiteral(node: TreeSitterSyntaxNode | null): string {
+export function stringLiteral(node: TreeSitterSyntaxNode | null): string {
   if (node === null) throw new Error('node cannot be null')
-  if (node.text[0] === 'r') return unescapeString(node.text.slice(2, -1))
+  if (node.text.startsWith('r#')) return unescapeString(node.text.slice(3, -2))
+  if (node.text.startsWith('r')) return unescapeString(node.text.slice(2, -1))
   return unescapeString(node.text.slice(1, -1))
 }
 
-// rust
 function unescapeString(s: string): string {
   return s.replace(/\\\\/g, '\\')
 }

--- a/test/language/rustLanguage.test.ts
+++ b/test/language/rustLanguage.test.ts
@@ -1,0 +1,44 @@
+import assert from 'assert'
+
+import { stringLiteral } from '../../src/language/rustLanguage.js'
+import { TreeSitterSyntaxNode } from '../../src/language/types.js'
+
+describe('rustLanguage', () => {
+  it('should extract string literal pattern', () => {
+    const cases = [
+      {
+        input: '"the bee\'s knees"',
+        expected: "the bee's knees",
+      },
+      {
+        input: '"a {uuid}"',
+        expected: 'a {uuid}',
+      },
+      {
+        input: 'r"^a regexp$"',
+        expected: '^a regexp$',
+      },
+      {
+        // eslint-disable-next-line
+        input: 'r"^stream (\w+) field (\w+) is a key$"',
+        // eslint-disable-next-line
+        expected: '^stream (\w+) field (\w+) is a key$',
+      },
+      {
+        input: 'r#"I have cucumber in my belly"#',
+        expected: 'I have cucumber in my belly',
+      },
+    ]
+
+    cases.forEach(({ input, expected }) => {
+      const node: TreeSitterSyntaxNode = {
+        type: '',
+        text: input,
+        children: [],
+        startPosition: { row: 0, column: 0 },
+        endPosition: { row: 0, column: 0 },
+      }
+      assert.strictEqual(stringLiteral(node), expected)
+    })
+  })
+})


### PR DESCRIPTION
### 🤔 What's changed?

Check for 'r#' strings in Rust and exclude elements exclude all elements except for the string content itself.

### ⚡️ What's your motivation? 

Fixes cucumber/vscode#202.

Raw strings in Rust of the format `r""` are currently supported. However, `r#""#` raw strings are unsupported.

### 🏷️ What kind of change is this?

- :bug: Bug fix (non-breaking change which fixes a defect)

### 📋 Checklist:

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)
- [x] I've changed the behaviour of the code
  - [x] I have added/updated tests to cover my changes.
- [x] Users should know about my change
  - [x] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request.