### PR TITLE
Line continuations for rust step definitions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 ### Fixed
 - (Rust) Support for r# raw strings with step definition patterns ([#176](https://github.com/cucumber/language-service/pull/176))
-
-### Fixed
+- (Rust) Line continuation characters in rust step definition patterns ([#179](https://github.com/cucumber/language-service/pull/179))
 - (Python) Unexpected spaces and commas in generated step definitions [#160](https://github.com/cucumber/language-service/issues/160)
 
 ## [1.4.1] - 2023-07-16

--- a/src/language/rustLanguage.ts
+++ b/src/language/rustLanguage.ts
@@ -111,9 +111,17 @@ fn {{ #lowercase }}{{ #underscore }}{{ expression }}{{ /underscore }}{{ /lowerca
 
 export function stringLiteral(node: TreeSitterSyntaxNode | null): string {
   if (node === null) throw new Error('node cannot be null')
-  if (node.text.startsWith('r#')) return unescapeString(node.text.slice(3, -2))
-  if (node.text.startsWith('r')) return unescapeString(node.text.slice(2, -1))
-  return unescapeString(node.text.slice(1, -1))
+
+  let result
+  if (node.text.startsWith('r#')) result = unescapeString(node.text.slice(3, -2))
+  else if (node.text.startsWith('r')) result = unescapeString(node.text.slice(2, -1))
+  else result = unescapeString(node.text.slice(1, -1))
+
+  return stripLineContinuation(result)
+}
+
+export function stripLineContinuation(s: string): string {
+  return s.replace(/\\\n\s*/g, '')
 }
 
 function unescapeString(s: string): string {

--- a/test/language/rustLanguage.test.ts
+++ b/test/language/rustLanguage.test.ts
@@ -1,6 +1,6 @@
 import assert from 'assert'
 
-import { stringLiteral } from '../../src/language/rustLanguage.js'
+import { stringLiteral, stripLineContinuation } from '../../src/language/rustLanguage.js'
 import { TreeSitterSyntaxNode } from '../../src/language/types.js'
 
 describe('rustLanguage', () => {
@@ -39,6 +39,63 @@ describe('rustLanguage', () => {
         endPosition: { row: 0, column: 0 },
       }
       assert.strictEqual(stringLiteral(node), expected)
+    })
+  })
+
+  it('should strip line continuations from expressions', () => {
+    const cases = [
+      {
+        // Single line continuation
+        input: '"Line \\\n  continuation"',
+        expected: '"Line continuation"',
+      },
+      {
+        input: '"Multiple \\\n  line \\\n  continuations"',
+        expected: '"Multiple line continuations"',
+      },
+      {
+        // Continuation with consecutive new lines
+        input: '"Continuation with \\\n\n  consecutive new lines"',
+        expected: '"Continuation with consecutive new lines"',
+      },
+      {
+        // No space before continuation
+        input: '"No space\\\n  before continuation"',
+        expected: '"No spacebefore continuation"',
+      },
+      {
+        // Multiple spaces before continuation
+        input: '"Two spaces  \\\n  before continuation"',
+        expected: '"Two spaces  before continuation"',
+      },
+      {
+        // Ends with escape character
+        input: '"Escaped backslash \\"',
+        expected: '"Escaped backslash \\"',
+      },
+      {
+        // Line continuation with extra space
+        input: '"this \\ line \\\nshould too"',
+        expected: '"this \\ line should too"',
+      },
+    ]
+
+    cases.forEach(({ input, expected }) => {
+      assert.strictEqual(stripLineContinuation(input), expected)
+    })
+  })
+
+  it('should not strip invalid line continuations from expressions', () => {
+    const cases = [
+      {
+        // Space after continuation but before new line
+        input: '"Space after continuation \\ \n  but before new line"',
+        expected: '"Space after continuation \\ \n  but before new line"',
+      },
+    ]
+
+    cases.forEach(({ input, expected }) => {
+      assert.strictEqual(stripLineContinuation(input), expected)
     })
   })
 })

--- a/test/language/rustLanguage.test.ts
+++ b/test/language/rustLanguage.test.ts
@@ -69,14 +69,19 @@ describe('rustLanguage', () => {
         expected: '"Two spaces  before continuation"',
       },
       {
-        // Ends with escape character
-        input: '"Escaped backslash \\"',
-        expected: '"Escaped backslash \\"',
-      },
-      {
         // Line continuation with extra space
         input: '"this \\ line \\\nshould too"',
         expected: '"this \\ line should too"',
+      },
+      {
+        // Ends with line continuation
+        input: '"Ends with continuation\\\n"',
+        expected: '"Ends with continuation"',
+      },
+      {
+        // Ends with line continuation and whitespace
+        input: '"Ends with continuation and whitespace\\\n "',
+        expected: '"Ends with continuation and whitespace"',
       },
     ]
 
@@ -91,6 +96,11 @@ describe('rustLanguage', () => {
         // Space after continuation but before new line
         input: '"Space after continuation \\ \n  but before new line"',
         expected: '"Space after continuation \\ \n  but before new line"',
+      },
+      {
+        // Ends with escape character
+        input: '"Escaped backslash \\"',
+        expected: '"Escaped backslash \\"',
       },
     ]
 


### PR DESCRIPTION
### 🤔 What's changed?

Support line continuation characters for step definition patterns written in rust.

### ⚡️ What's your motivation? 

Fixes cucumber/vscode#116.

<img width="543" alt="Screenshot 2024-01-15 at 22 02 57" src="https://github.com/cucumber/language-service/assets/5904340/eab1bd73-cf1b-45a6-acb0-2143f272576b">

### 🏷️ What kind of change is this?

- :bug: Bug fix (non-breaking change which fixes a defect)

### ♻️ Anything particular you want feedback on?

What gherkin text will match the below step definition pattern where there are characters on the line after the line continuation? `cucumber-rs` does not throw any error for this pattern; however, was unable to find a matching gherkin test step.

```rust
#[given("a line continuation \
")]
fn hungry_cat(world: &mut AnimalWorld) {
    world.cat.hungry = true;
}
```

### 📋 Checklist:

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)
- [x] I've changed the behaviour of the code
  - [x] I have added/updated tests to cover my changes.
- [x] Users should know about my change
  - [x] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request.