### PR TITLE
Fix/tree sitter parsing expression failure

### DIFF
--- a/src/language/SourceAnalyzer.ts
+++ b/src/language/SourceAnalyzer.ts
@@ -1,7 +1,12 @@
 import { RegExps, StringOrRegExp } from '@cucumber/cucumber-expressions'
 import { LocationLink } from 'vscode-languageserver-types'
 
-import { createLocationLink, makeParameterType, syntaxNode } from './helpers.js'
+import {
+  createLocationLink,
+  makeParameterType,
+  stripBlacklistedExpressions,
+  syntaxNode,
+} from './helpers.js'
 import { getLanguage } from './languages.js'
 import {
   Language,
@@ -136,7 +141,10 @@ language: ${source.languageName}
   private parse(source: Source<LanguageName>): TreeSitterTree {
     let tree: TreeSitterTree | undefined = this.treeByContent.get(source)
     if (!tree) {
-      this.treeByContent.set(source, (tree = this.parserAdapter.parser.parse(source.content)))
+      // This is currently necessary since the tree-sitter parser currently errors on certain expressions
+      const content = stripBlacklistedExpressions(source.content)
+      tree = this.parserAdapter.parser.parse(content)
+      this.treeByContent.set(source, tree)
     }
     return tree
   }

--- a/src/language/SourceAnalyzer.ts
+++ b/src/language/SourceAnalyzer.ts
@@ -142,7 +142,7 @@ language: ${source.languageName}
     let tree: TreeSitterTree | undefined = this.treeByContent.get(source)
     if (!tree) {
       // This is currently necessary since the tree-sitter parser currently errors on certain expressions
-      const content = stripBlacklistedExpressions(source.content)
+      const content = stripBlacklistedExpressions(source.content, source.languageName)
       tree = this.parserAdapter.parser.parse(content)
       this.treeByContent.set(source, tree)
     }

--- a/src/language/helpers.ts
+++ b/src/language/helpers.ts
@@ -1,7 +1,13 @@
 import { ParameterType, RegExps } from '@cucumber/cucumber-expressions'
 import { DocumentUri, LocationLink, Range } from 'vscode-languageserver-types'
 
-import { Link, NodePredicate, TreeSitterQueryMatch, TreeSitterSyntaxNode } from './types'
+import {
+  LanguageName,
+  Link,
+  NodePredicate,
+  TreeSitterQueryMatch,
+  TreeSitterSyntaxNode,
+} from './types'
 
 export function syntaxNode(match: TreeSitterQueryMatch, name: string): TreeSitterSyntaxNode | null {
   const nodes = syntaxNodes(match, name)
@@ -76,21 +82,33 @@ function flatten(node: TreeSitterSyntaxNode): TreeSitterSyntaxNode[] {
  * This constant represents a list of regular expressions
  * that should be stripped from the content of a file.
  */
-export const BLACKLISTED_EXPRESSIONS: RegExp[] = [
-  /*
-   * This regular expression matches sequences of decorators applied to a class,
-   * potentially including type parameters and arguments.
-   * The regex supports matching these patterns preceding
-   * an optionally exported class definition.
-   */
-  /(@(\w+)(?:<[^>]+>)?\s*(?:\([^)]*\))?\s*)*(?=\s*(export)*\s+class)/g,
-]
+export const BLACKLISTED_EXPRESSIONS: {
+  [key in LanguageName]: RegExp[]
+} = {
+  tsx: [
+    /*
+     * This regular expression matches sequences of decorators applied to a class,
+     * potentially including type parameters and arguments.
+     * The regex supports matching these patterns preceding
+     * an optionally exported class definition.
+     */
+    /(@(\w+)(?:<[^>]+>)?\s*(?:\([^)]*\))?\s*)*(?=\s*(export)*\s+class)/g,
+  ],
+  java: [],
+  c_sharp: [],
+  php: [],
+  python: [],
+  ruby: [],
+  rust: [],
+  javascript: [],
+}
 
 /**
  *
  * Strips blacklisted expressions from the given content.
  *
  * @param content The content to strip blacklisted expressions from.
+ * @param languageName The name of the language to use for stripping.
  *
  * @returns The content with blacklisted expressions stripped.
  *
@@ -104,7 +122,7 @@ export const BLACKLISTED_EXPRESSIONS: RegExp[] = [
  *  "public bar() { }\n" ++
  *  "}"
  *
- * const strippedContent = stripBlacklistedExpressions(content)
+ * const strippedContent = stripBlacklistedExpressions(content, 'tsx')
  * console.log(strippedContent)
  *
  * // Output:
@@ -115,6 +133,9 @@ export const BLACKLISTED_EXPRESSIONS: RegExp[] = [
  *
  * ```
  */
-export function stripBlacklistedExpressions(content: string): string {
-  return BLACKLISTED_EXPRESSIONS.reduce((acc, regExp) => acc.replace(regExp, ''), content)
+export function stripBlacklistedExpressions(content: string, languageName: LanguageName): string {
+  return BLACKLISTED_EXPRESSIONS[languageName].reduce(
+    (acc, regExp) => acc.replace(regExp, ''),
+    content
+  )
 }

--- a/src/language/helpers.ts
+++ b/src/language/helpers.ts
@@ -70,3 +70,51 @@ export function filter(
 function flatten(node: TreeSitterSyntaxNode): TreeSitterSyntaxNode[] {
   return node.children.reduce((r, o) => [...r, ...flatten(o)], [node])
 }
+
+/**
+ *
+ * This constant represents a list of regular expressions
+ * that should be stripped from the content of a file.
+ */
+export const BLACKLISTED_EXPRESSIONS: RegExp[] = [
+  /*
+   * This regular expression matches sequences of decorators applied to a class,
+   * potentially including type parameters and arguments.
+   * The regex supports matching these patterns preceding
+   * an optionally exported class definition.
+   */
+  /(@(\w+)(?:<[^>]+>)?\s*(?:\([^)]*\))?\s*)*(?=\s*(export)*\s+class)/g,
+]
+
+/**
+ *
+ * Strips blacklisted expressions from the given content.
+ *
+ * @param content The content to strip blacklisted expressions from.
+ *
+ * @returns The content with blacklisted expressions stripped.
+ *
+ * @example
+ *
+ * ```typescript
+ * const content =
+ *  "@decorator\n" ++
+ *  "export class Foo {\n" ++
+ *  "@decorator\n" ++
+ *  "public bar() { }\n" ++
+ *  "}"
+ *
+ * const strippedContent = stripBlacklistedExpressions(content)
+ * console.log(strippedContent)
+ *
+ * // Output:
+ * "export class Foo {\n" ++
+ * "@decorator\n" ++
+ * "public bar() { }\n" ++
+ * "}"
+ *
+ * ```
+ */
+export function stripBlacklistedExpressions(content: string): string {
+  return BLACKLISTED_EXPRESSIONS.reduce((acc, regExp) => acc.replace(regExp, ''), content)
+}


### PR DESCRIPTION
<!---
Thanks for helping to make Cucumber better! 💖

You can feel free to open a "Draft" status pull request if you're not ready for feedback yet.

Don't worry about getting everything perfect! We're here to help and will coach you through
to getting your pull request ready to merge.

The prompts below are for guidance to help you describe your change in a way that is most 
likely to make sense to other people when they are reviewing it. Still, it's just a guide, 
so feel free to delete anything that doesn't feel appropriate, and add anything additional 
that seems like it would provide useful context. 👏🏻
-->

### 🤔 What's changed?

A helper function `stripBlacklistedExpressions` to help with tree-sitter's parsing in certain edge cases where parsing is currently erroneous.

### ⚡️ What's your motivation? 

We're currently using [playwright-bdd](https://github.com/vitalets/playwright-bdd) so that we can use playwright as our test runner and cucumber for BDD. Unfortunately, the language server is currently not working for the decorator syntax for `playwright-bdd` which can be found [here](https://vitalets.github.io/playwright-bdd/#/./decorators).

The reason for this seems to be that the version of `tree-sitter` that is used by `@cucumber/language-service` is unable to parse TypeScript files that contain decorators for classes. This PR is an interim fix for that until either `tree-sitter` addresses the issue (if the issue is on their behalf - I'm not sure) or until `@cucumber/language-service` changes the `tree-sitter` parsing to work as expected.

### 🏷️ What kind of change is this?

<!--- Delete any options that are not relevant -->

- :bug: Bug fix (non-breaking change which fixes a defect)

### ♻️ Anything particular you want feedback on?

<!-- 
Is there anything in this change you're unsure about, or would 
particularly like reviewers to give you feedback on?
-->

### 📋 Checklist:

<!--- 
This is to help you remember all the little things we often forget to do!

Feel free to delete any tasks that are not relevant, or add new ones.
-->

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)
- [x] I've changed the behaviour of the code
  - [ ] I have added/updated tests to cover my changes.
- [x] Users should know about my change
  - [ ] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request.

----

*This text was originally generated from a [template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates), then edited by hand. [You can modify the template here.](https://github.com/cucumber/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
