### PR TITLE
Index failure with partial Python parameter match

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 ### Fixed
+- (Python) Fix index failures from partial parameter type matches ([#196](https://github.com/cucumber/language-service/pull/196))
 - (Rust) Support for r# raw strings with step definition patterns ([#176](https://github.com/cucumber/language-service/pull/176))
 - (Rust) Line continuation characters in rust step definition patterns ([#179](https://github.com/cucumber/language-service/pull/179))
 - (Python) Unexpected spaces and commas in generated step definitions [#160](https://github.com/cucumber/language-service/issues/160)

--- a/src/language/pythonLanguage.ts
+++ b/src/language/pythonLanguage.ts
@@ -50,18 +50,52 @@ export const pythonLanguage: Language = {
           name: (identifier) @name-key
           value: (string) @name
           (#eq? @name-key "name")
-        )?
+        )
         (keyword_argument
           name: (identifier) @regexp-key
           value: (string) @expression
           (#eq? @regexp-key "regexp")
-        )?
+        )
+    ))@root`,
+    `(call
+      arguments: (argument_list
+        (keyword_argument
+          name: (identifier) @name-key
+          value: (string) @name
+          (#eq? @name-key "name")
+        )
         (keyword_argument
           name: (identifier) @regexp-key
           value: (concatenated_string) @expression
           (#eq? @regexp-key "regexp")
-        )?
-     ))@root`,
+        )
+    ))@root`,
+    `(call
+      arguments: (argument_list
+          (keyword_argument
+          name: (identifier) @regexp-key
+          value: (string) @expression
+          (#eq? @regexp-key "regexp")
+        )
+        (keyword_argument
+          name: (identifier) @name-key
+          value: (string) @name
+          (#eq? @name-key "name")
+        )
+    ))@root`,
+    `(call
+      arguments: (argument_list
+        (keyword_argument
+          name: (identifier) @regexp-key
+          value: (concatenated_string) @expression
+          (#eq? @regexp-key "regexp")
+        )
+        (keyword_argument
+          name: (identifier) @name-key
+          value: (string) @name
+          (#eq? @name-key "name")
+        )
+    ))@root`,
   ],
   defineStepDefinitionQueries: [
     `

--- a/test/language/testdata/python/ParameterTypes.py
+++ b/test/language/testdata/python/ParameterTypes.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+
 from cucumber_expressions.parameter_type import ParameterType
 
 ParameterType(
@@ -9,12 +10,12 @@ ParameterType(
 
 ParameterType(
     name="date",
-    regexp="/\d{4}-\d{2}-\d{2}/",
     transformer=lambda x: datetime.datetime(x),
+    regexp="/\d{4}-\d{2}-\d{2}/",
 )
 
 ParameterType(
-    name="planet",
-    regexp="jupiter|mars|tellus",
     transformer=lambda x: x,
+    regexp="jupiter|mars|tellus",
+    name="planet",
 )


### PR DESCRIPTION
<!---
Thanks for helping to make Cucumber better! 💖

You can feel free to open a "Draft" status pull request if you're not ready for feedback yet.

Don't worry about getting everything perfect! We're here to help and will coach you through
to getting your pull request ready to merge.

The prompts below are for guidance to help you describe your change in a way that is most 
likely to make sense to other people when they are reviewing it. Still, it's just a guide, 
so feel free to delete anything that doesn't feel appropriate, and add anything additional 
that seems like it would provide useful context. 👏🏻
-->

### 🤔 What's changed?

<!-- Describe your changes in detail -->

- Refined tree-sitter query for Python Parameter matches

### ⚡️ What's your motivation? 

<!-- 
What motivated you to propose this change? Does it fix a bug? Add a new feature?
If it fixes an open issue, you can link to the issue here, e.g. "Fixes #99"
-->

- Fixes #181

The Parameter Type tree-sitter query for Python allowed three optional keyword arguments, 1 for the name argument and 2 for the regular expressions argument in two different formats (`string` and `concatenated-string`).

This works fine with valid parameter type definitions using the keyword arguments in the order in which they are declared. However, the query fails in the following scenarios:

- The keyword arguments order is in reverse order. This fails to detect the parameter type but does not prevent reading from that glue file or other glue files.
- Any Python callable with either of `name` or `regexp` as keyword arguments yields a partial match (as the query specifies more arguments as optional), however the language service requires both and yields an unhandled exception as a result which prevents reading from all glue files entirely.

### 🏷️ What kind of change is this?

<!--- Delete any options that are not relevant -->

- :bug: Bug fix (non-breaking change which fixes a defect)

### ♻️ Anything particular you want feedback on?

<!-- 
Is there anything in this change you're unsure about, or would 
particularly like reviewers to give you feedback on?
-->

### 📋 Checklist:

<!--- 
This is to help you remember all the little things we often forget to do!

Feel free to delete any tasks that are not relevant, or add new ones.
-->

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)
- [x] I've changed the behaviour of the code
  - [x] I have added/updated tests to cover my changes.
- [x] Users should know about my change
  - [x] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request.

----

*This text was originally generated from a [template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates), then edited by hand. [You can modify the template here.](https://github.com/cucumber/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
