### PR TITLE
Support 'And' and 'But' annotations in Ruby glue files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Fixed
+- (Ruby) Support `And` and `But` step definition annotations
 
 ## [1.6.0] - 2024-05-12
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 ### Fixed
-- (Ruby) Support `And` and `But` step definition annotations
+- (Ruby) Support `And` and `But` step definition annotations ([#211](https://github.com/cucumber/language-service/pull/211))
 
 ## [1.6.0] - 2024-05-12
 ### Added

--- a/src/language/rubyLanguage.ts
+++ b/src/language/rubyLanguage.ts
@@ -76,7 +76,7 @@ export const rubyLanguage: Language = {
       (regex) @expression
     ]
   )
-  (#match? @method "(Given|When|Then)$")
+  (#match? @method "(Given|When|Then|And|But)$")
 ) @root
 `,
   ],

--- a/test/language/testdata/ruby/StepDefinitions.rb
+++ b/test/language/testdata/ruby/StepDefinitions.rb
@@ -1,16 +1,16 @@
 Given('a {uuid}') do |uuid|
 end
 
-Given('a {date}') do |date|
+When('a {date}') do |date|
 end
 
-Given('a {planet}') do |planet|
+Then('a {planet}') do |planet|
 end
 
-Given(/^a regexp$/) do
+And(/^a regexp$/) do
 end
 
-Given('an {undefined-parameter}') do |date|
+But('an {undefined-parameter}') do |date|
 end
 
 Given('the bee\'s knees') do |date|


### PR DESCRIPTION
### 🤔 What's changed?

- Support for `And` and `But` in Ruby glue files
- Extend Ruby testdata to test against `When`, `Then`, `And` and `But`

### ⚡️ What's your motivation? 

- Closes cucumber/vscode#233
- Improves unit test suite

### 🏷️ What kind of change is this?

- :bug: Bug fix (non-breaking change which fixes a defect)

### 📋 Checklist:

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)
- [x] I've changed the behaviour of the code
  - [x] I have added/updated tests to cover my changes.
- [x] Users should know about my change
  - [x] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request.

----

*This text was originally generated from a [template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates), then edited by hand. [You can modify the template here.](https://github.com/cucumber/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
