### PR TITLE
Syntax highlighting for comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Added
+- Syntax highlighting for comments (`#`)
 
 ## [1.6.0] - 2024-05-12
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 ### Added
-- Syntax highlighting for comments (`#`)
+- Syntax highlighting for comments (`#`) ([#212](https://github.com/cucumber/language-service/pull/212))
 
 ## [1.6.0] - 2024-05-12
 ### Added

--- a/test/service/getGherkinSemanticTokens.test.ts
+++ b/test/service/getGherkinSemanticTokens.test.ts
@@ -58,6 +58,7 @@ Feature: a
     ])
     const actual = tokenize(gherkinSource, semanticTokens.data)
     const expected: TokenWithType[] = [
+      ['# some comment', SemanticTokenTypes.comment],
       ['@foo', SemanticTokenTypes.type],
       ['@bar', SemanticTokenTypes.type],
       ['Feature', SemanticTokenTypes.keyword],


### PR DESCRIPTION
### 🤔 What's changed?

- Syntax highlighting for comments (`#`)

The [Language Server Protocol semantic tokens specification](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_semanticTokens) accepts non-negative integers for relative text positions by default. As the [gherkin-util's document walker](https://github.com/cucumber/gherkin-utils/blob/86021b27b17d584e66fbfe21ecf9abe46a01086b/javascript/src/walkGherkinDocument.ts) processes table rows before comments, comments can have negative relative positions and break syntax highlighting of some tokens. As such, post-processing has been introduced to correct relative positions to always be positive.

#### Before

![Screenshot 2024-05-19 094023](https://github.com/cucumber/language-service/assets/5904340/e2beb78a-ac7d-4740-8350-6b496d2380c1)

#### After

![Screenshot 2024-05-19 094111](https://github.com/cucumber/language-service/assets/5904340/cdd27a8b-c469-4df3-9c6c-22240f2a1d4c)

### ⚡️ What's your motivation? 

- Match other common language implementations of providing syntax highlighting for comments
- Match common syntax highlighting for gherkin (such as the [Cucumber docs](https://cucumber.io/) - see below)

    ![image](https://static1.smartbear.co/cucumber/media/images/home/code-example-white.svg)

### 🏷️ What kind of change is this?

- :zap: New feature (non-breaking change which adds new behaviour)

### 📋 Checklist:

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)
- [x] I've changed the behaviour of the code
  - [x] I have added/updated tests to cover my changes.
- [x] Users should know about my change
  - [x] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request.