### PR TITLE
Behave title decorator variants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 ### Fixed
 - (Ruby) Support `And` and `But` step definition annotations ([#211](https://github.com/cucumber/language-service/pull/211))
+- (Python) Title variants of Behave's decorators (`Step`, `Given`, `When`, `Then`)
 
 ## [1.6.0] - 2024-05-12
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 ### Fixed
 - (Ruby) Support `And` and `But` step definition annotations ([#211](https://github.com/cucumber/language-service/pull/211))
-- (Python) Title variants of Behave's decorators (`Step`, `Given`, `When`, `Then`)
+- (Python) Title variants of Behave's decorators (`Step`, `Given`, `When`, `Then`) ([#213](https://github.com/cucumber/language-service/pull/213))
 
 ## [1.6.0] - 2024-05-12
 ### Added

--- a/src/language/pythonLanguage.ts
+++ b/src/language/pythonLanguage.ts
@@ -98,7 +98,7 @@ export const pythonLanguage: Language = {
           arguments: (argument_list (string) @expression)
         )
       )
-      (#match? @method "(given|when|then|step)")
+      (#match? @method "(given|when|then|step|Given|When|Then|Step)")
     ) @root`,
   ],
   snippetParameters: {

--- a/test/language/testdata/python/StepDefinitions.py
+++ b/test/language/testdata/python/StepDefinitions.py
@@ -23,13 +23,13 @@ def step_undef(context, planet):
     assert planet
 
 
-@given("/^a regexp$/")
+@Step("/^a regexp$/")
 def step_re(context, expression):
     """Test Re."""
     assert expression
 
 
-@given("the bee's knees")
+@Given("the bee's knees")
 def step_bees(context, expression):
     """Test Re."""
     assert expression


### PR DESCRIPTION
### 🤔 What's changed?

- Support for title variants of Behave's decorators (`Step`, `Given`, `When`, `Then`)

### ⚡️ What's your motivation? 

- Support all Behave decorators - ensuring compatibility for users using those variants

### 🏷️ What kind of change is this?

- :bug: Bug fix (non-breaking change which fixes a defect)

### 📋 Checklist:

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)
- [x] I've changed the behaviour of the code
  - [x] I have added/updated tests to cover my changes.
- [x] Users should know about my change
  - [x] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request.