### PR TITLE
Fix: Find godog step definitions within `method_declaration`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - (Ruby) Support `And` and `But` step definition annotations ([#211](https://github.com/cucumber/language-service/pull/211))
 - (Python) Title variants of Behave's decorators (`Step`, `Given`, `When`, `Then`) ([#213](https://github.com/cucumber/language-service/pull/213))
 - (PHP) Scoped query to match annotations only (`@Given`) ([#214](https://github.com/cucumber/language-service/pull/214))
+- (Go) Find godog step definitions within `method_declaration` ([#215](https://github.com/cucumber/language-service/pull/215))
 
 ## [1.6.0] - 2024-05-12
 ### Added

--- a/src/language/goLanguage.ts
+++ b/src/language/goLanguage.ts
@@ -42,6 +42,34 @@ export const goLanguage: Language = {
             )
             (#match? @annotation-name "Given|When|Then|Step")))))@root
     `,
+    `(method_declaration
+      body: (block
+        (expression_statement
+          (call_expression
+            function: (selector_expression
+              field: (field_identifier) @annotation-name
+            )
+            arguments: (argument_list
+              [
+                (raw_string_literal) @expression
+              ]
+            )
+            (#match? @annotation-name "Given|When|Then|Step")))))@root
+    `,
+    `(method_declaration
+      body: (block
+        (expression_statement
+          (call_expression
+            function: (selector_expression
+              field: (field_identifier) @annotation-name
+            )
+            arguments: (argument_list
+              [
+                (interpreted_string_literal) @expression
+              ]
+            )
+            (#match? @annotation-name "Given|When|Then|Step")))))@root
+    `,
   ],
   snippetParameters: {
     int: { type: 'int', name: 'i' },

--- a/test/language/ExpressionBuilder.test.ts
+++ b/test/language/ExpressionBuilder.test.ts
@@ -109,7 +109,7 @@ Please register a ParameterType for 'undefined-parameter'`,
         }
         assert(matched, 'The generated expressions did not match parameter type {date}')
       } else {
-        assert.deepStrictEqual(expressions, [/^a regexp$/])
+        assert.deepStrictEqual(expressions, [/^a regexp$/, /^I test this change$/])
         assert.deepStrictEqual(errors, ['There is already a parameter type with name int'])
       }
     })

--- a/test/language/testdata/go/StepDefinitions.go
+++ b/test/language/testdata/go/StepDefinitions.go
@@ -9,3 +9,7 @@ func a_regexp() {}
 func InitializeScenario(ctx *godog.ScenarioContext) {
 	ctx.Given(`^a regexp$`, a_regexp)
 }
+
+func (s suite) Steps(sc *godog.ScenarioContext) {
+    sc.Given(`^I test this change$`, a_regexp)
+}

--- a/test/language/testdata/php/StepDefinitions.php
+++ b/test/language/testdata/php/StepDefinitions.php
@@ -11,5 +11,12 @@ class StepDefinitions
     {
         // Given
     }
-}
 
+    /**
+     * @Given ^I test this change$
+     */
+    public function test_changes()
+    {
+        // Given
+    }
+}


### PR DESCRIPTION
<!---
Thanks for helping to make Cucumber better! 💖

You can feel free to open a "Draft" status pull request if you're not ready for feedback yet.

Don't worry about getting everything perfect! We're here to help and will coach you through
to getting your pull request ready to merge.

The prompts below are for guidance to help you describe your change in a way that is most 
likely to make sense to other people when they are reviewing it. Still, it's just a guide, 
so feel free to delete anything that doesn't feel appropriate, and add anything additional 
that seems like it would provide useful context. 👏🏻
-->

### 🤔 What's changed?

Add treesitter queries for finding godog steps within methods.

### ⚡️ What's your motivation? 

We currently load up our godog steps from a method with variable attributes attached, so the language service isn't finding them.

So, while this currently works:
```go
func Steps(sc *godog.ScenarioContext) {
    sc.Given(`^I test this change$`, handler)
}
```

This doesn't:
```go
func (s suite) Steps(sc *godog.ScenarioContext) {
    sc.Given(`^I test this change$`, s.handler)
}
```

### 🏷️ What kind of change is this?

<!--- Delete any options that are not relevant -->

- :bug: Bug fix (non-breaking change which fixes a defect)

### ♻️ Anything particular you want feedback on?

<!-- 
Is there anything in this change you're unsure about, or would 
particularly like reviewers to give you feedback on?
-->

Nope it's all good.

### 📋 Checklist:

<!--- 
This is to help you remember all the little things we often forget to do!

Feel free to delete any tasks that are not relevant, or add new ones.
-->

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)
- [x] I've changed the behaviour of the code
  - [x] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [x] Users should know about my change
  - [x] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request.

----

*This text was originally generated from a [template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates), then edited by hand. [You can modify the template here.](https://github.com/cucumber/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
