### PR TITLE
Compiled cjs step definitions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Added
+- (Javascript) Support for compiled cjs style step definitions ([#222](https://github.com/cucumber/language-service/pull/222))
+
 ### Fixed
 - (Ruby) Support `And` and `But` step definition annotations ([#211](https://github.com/cucumber/language-service/pull/211))
 - (Python) Title variants of Behave's decorators (`Step`, `Given`, `When`, `Then`) ([#213](https://github.com/cucumber/language-service/pull/213))

--- a/src/language/javascriptLanguage.ts
+++ b/src/language/javascriptLanguage.ts
@@ -3,6 +3,31 @@ import { Language } from './types.js'
 
 export const javascriptLanguage: Language = {
   ...tsxLanguage,
+  defineStepDefinitionQueries: [
+    ...tsxLanguage.defineStepDefinitionQueries,
+    // Matcher for compiled cjs format, with step definitions in the form:
+    // (0, some_cucumber_import.Given)("step title here", function...)
+    `
+(call_expression
+  function: (parenthesized_expression
+    (sequence_expression
+      (number)
+      (member_expression
+        property: (property_identifier) @function-name
+      )
+    )
+  )
+  arguments: (arguments
+    [
+      (string) @expression
+      (regex) @expression
+      (template_string) @expression
+    ]
+  )
+  (#match? @function-name "Given|When|Then")
+) @root
+`,
+  ],
   defaultSnippetTemplate: `
 {{ keyword }}('{{ expression }}', ({{ #parameters }}{{ #seenParameter }}, {{ /seenParameter }}{{ name }}{{ /parameters }}) => {
   // {{ blurb }}

--- a/src/language/javascriptLanguage.ts
+++ b/src/language/javascriptLanguage.ts
@@ -5,28 +5,42 @@ export const javascriptLanguage: Language = {
   ...tsxLanguage,
   defineStepDefinitionQueries: [
     ...tsxLanguage.defineStepDefinitionQueries,
-    // Matcher for compiled cjs format, with step definitions in the form:
-    // (0, some_cucumber_import.Given)("step title here", function...)
-    `
-(call_expression
-  function: (parenthesized_expression
-    (sequence_expression
-      (number)
-      (member_expression
-        property: (property_identifier) @function-name
+    // Compiled cjs step definitions of the format:
+    // (0, some_cucumber_import.Given)("step pattern here", function...)
+    `(call_expression
+      function: (parenthesized_expression
+        (sequence_expression
+          (member_expression
+            property: (property_identifier) @function-name
+          )
+        )
       )
-    )
-  )
-  arguments: (arguments
-    [
-      (string) @expression
-      (regex) @expression
-      (template_string) @expression
-    ]
-  )
-  (#match? @function-name "Given|When|Then")
-) @root
-`,
+      arguments: (arguments
+        [
+          (string) @expression
+          (regex) @expression
+          (template_string) @expression
+        ]
+      )
+      (#match? @function-name "Given|When|Then")
+    ) @root`,
+    // Compiled cjs step definitions of the format:
+    // (0, Given)("step pattern here", function...)
+    `(call_expression
+      function: (parenthesized_expression
+        (sequence_expression
+          (identifier) @function-name
+        )
+      )
+      arguments: (arguments
+        [
+          (string) @expression
+          (regex) @expression
+          (template_string) @expression
+        ]
+      )
+      (#match? @function-name "Given|When|Then")
+    ) @root`,
   ],
   defaultSnippetTemplate: `
 {{ keyword }}('{{ expression }}', ({{ #parameters }}{{ #seenParameter }}, {{ /seenParameter }}{{ name }}{{ /parameters }}) => {

--- a/test/language/ExpressionBuilder.test.ts
+++ b/test/language/ExpressionBuilder.test.ts
@@ -87,6 +87,7 @@ function defineContract(makeParserAdapter: () => ParserAdapter) {
           'a {planet}',
           /^a regexp$/,
           "the bee's knees",
+          ...(languageName === 'javascript' ? ['a compiled format'] : []),
         ])
         assert.deepStrictEqual(errors, [
           'There is already a parameter type with name int',

--- a/test/language/testdata/javascript/StepDefinitions.js
+++ b/test/language/testdata/javascript/StepDefinitions.js
@@ -24,7 +24,7 @@ Given('an {undefined-parameter}', async function (date) {
   assert(date)
 })
 
-Given("the bee's knees", async function () {
+;(0, Given)("the bee's knees", async function () {
   assert(true)
 })
 

--- a/test/language/testdata/javascript/StepDefinitions.js
+++ b/test/language/testdata/javascript/StepDefinitions.js
@@ -1,4 +1,4 @@
-import { Given } from '@cucumber/cucumber'
+import cucumber, { Given } from '@cucumber/cucumber'
 import assert from 'assert'
 import React from 'react'
 
@@ -25,5 +25,9 @@ Given('an {undefined-parameter}', async function (date) {
 })
 
 Given("the bee's knees", async function () {
+  assert(true)
+})
+
+;(0, cucumber.Given)('a compiled format', async function () {
   assert(true)
 })


### PR DESCRIPTION
<!---
Thanks for helping to make Cucumber better! 💖

You can feel free to open a "Draft" status pull request if you're not ready for feedback yet.

Don't worry about getting everything perfect! We're here to help and will coach you through
to getting your pull request ready to merge.

The prompts below are for guidance to help you describe your change in a way that is most 
likely to make sense to other people when they are reviewing it. Still, it's just a guide, 
so feel free to delete anything that doesn't feel appropriate, and add anything additional 
that seems like it would provide useful context. 👏🏻
-->

### 🤔 What's changed?

Updated the javascript defineStepDefinitionQueries array to include a Tree-sitter query that matchs steps in the format found in compiled commonjs files.

Javascript steps in the following format will now be identified:
```javascript
;(0, cucumber_import.Given)('a compiled format', function () {
  ...
})
```

_NOTE: The function used for the second argument is completely ignored by the query - it makes no difference if it is async or not, the step will still be matched._

### ⚡️ What's your motivation? 

Fixes #187 - allows steps to be identified in compiled cjs/js files, usually needed when importing from other modules (aka in node_modules)

### 🏷️ What kind of change is this?

- :zap: New feature (non-breaking change which adds new behaviour)

### ♻️ Anything particular you want feedback on?

- Are the doc changes required/suitable?

### 📋 Checklist:

<!--- 
This is to help you remember all the little things we often forget to do!

Feel free to delete any tasks that are not relevant, or add new ones.
-->

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)
- [x] I've changed the behaviour of the code
  - [x] I have added/updated tests to cover my changes.

~~[ ] My change requires a change to the documentation _(potentially, not crucial though)_~~
- [x] Users should know about my change
  - [x] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request.

----

*This text was originally generated from a [template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates), then edited by hand. [You can modify the template here.](https://github.com/cucumber/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
