### PR TITLE
Drop support for end-of-life node version 16

### DIFF
--- a/.github/workflows/release-npm.yml
+++ b/.github/workflows/release-npm.yml
@@ -20,7 +20,8 @@ jobs:
           node-version: '18'
           cache: 'npm'
           cache-dependency-path: package-lock.json
-      - run: npm install-test
+      - run: npm ci
+      - run: npm run test
       - uses: cucumber/action-publish-npm@v1.1.1
         with:
           npm-token: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release-npm.yml
+++ b/.github/workflows/release-npm.yml
@@ -17,7 +17,7 @@ jobs:
           version: 2.0.24
       - uses: actions/setup-node@v4
         with:
-          node-version: '16'
+          node-version: '18'
           cache: 'npm'
           cache-dependency-path: package-lock.json
       - run: npm install-test

--- a/.github/workflows/test-javascript.yml
+++ b/.github/workflows/test-javascript.yml
@@ -20,10 +20,7 @@ jobs:
           - macos-latest
           - ubuntu-latest
           - windows-latest
-        # 14.x is broken with @typescript-eslint 6.0
-        # 16.12.0 has broken ESM support
-        # 17.x cannot install tree-sitter: https://github.com/tree-sitter/tree-sitter/issues/1503
-        node-version: ['16.11.x', '18.x']
+        node-version: ['18.x']
 
     steps:
       - name: set git core.autocrlf to 'input'

--- a/.github/workflows/test-javascript.yml
+++ b/.github/workflows/test-javascript.yml
@@ -37,9 +37,9 @@ jobs:
           node-version: ${{ matrix.node-version }}
           cache: 'npm'
           cache-dependency-path: package-lock.json
-      - run: npm install
+      - run: npm ci
         if: ${{ matrix.os != 'windows-latest' }}
-      - run: npm install --no-optional
+      - run: npm ci --no-optional
         if: ${{ matrix.os == 'windows-latest' }}
       - run: npm test
       - run: npm run eslint

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - (PHP) Scoped query to match annotations only (`@Given`) ([#214](https://github.com/cucumber/language-service/pull/214))
 - (Go) Find godog step definitions within `method_declaration` ([#215](https://github.com/cucumber/language-service/pull/215))
 
+### Removed
+- Dropped support for end-of-life Node version 16 ([#224](https://github.com/cucumber/language-service/pull/224))
+
 ## [1.6.0] - 2024-05-12
 ### Added
 - Diagnostics for marking steps as undefined in scenario outlines ([#210](https://github.com/cucumber/language-service/pull/210))


### PR DESCRIPTION
### 🤔 What's changed?

- Dropped Node version 16 support
- Change 'npm install' to 'npm ci' in pipeline

### ⚡️ What's your motivation? 

- [Node v16 is end of life](https://nodejs.org/en/about/previous-releases)
- Aligns with cucumber/gherkin-utils#74

### 🏷️ What kind of change is this?

- :boom: Breaking change (incompatible changes to the API)

### ♻️ Anything particular you want feedback on?

NA.

### 📋 Checklist:

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)
- [ ] I've changed the behaviour of the code
  - [ ] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [x] Users should know about my change
  - [x] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request.