### PR TITLE
Added behat arg detection, added related test

### DIFF
--- a/test/language/phpLanguage.test.ts
+++ b/test/language/phpLanguage.test.ts
@@ -1,0 +1,35 @@
+import assert from 'assert'
+
+import { behatifyStep } from '../../src/language/phpLanguage.js'
+
+describe('phpLanguage', () => {
+  it('should handle behat step definition', () => {
+    const cases = [
+      {
+        input: '@Given Hello world',
+        output: RegExp('Hello world'),
+      },
+      {
+        input: '@When Hello :world',
+        output: RegExp('Hello ([\\S]+|"[^"]+")'),
+      },
+      {
+        input: '@Then there is a :arg1, which costs £:arg2',
+        output: RegExp('there is a ([\\S]+|"[^"]+"), which costs £([\\S]+|"[^"]+")'),
+      },
+      {
+        input: '@Given /^there (?:is|are) (\\d+) monsters?$/',
+        output: RegExp('^there (?:is|are) (\\d+) monsters?$'),
+      },
+      {
+        input: '@Given /^Something (.*)$/i',
+        output: RegExp('^Something (.*)$', 'i'),
+      },
+    ]
+    cases.forEach(function (c) {
+      const result = behatifyStep(c.input)
+      assert(result instanceof RegExp)
+      assert.equal(result.toString(), c.output.toString())
+    })
+  })
+})


### PR DESCRIPTION
The test file contains valid Behat inputs.
Detected arguments are turned into regex.

<!---
Thanks for helping to make Cucumber better! 💖

You can feel free to open a "Draft" status pull request if you're not ready for feedback yet.

Don't worry about getting everything perfect! We're here to help and will coach you through
to getting your pull request ready to merge.

The prompts below are for guidance to help you describe your change in a way that is most 
likely to make sense to other people when they are reviewing it. Still, it's just a guide, 
so feel free to delete anything that doesn't feel appropriate, and add anything additional 
that seems like it would provide useful context. 👏🏻
-->

### 🤔 What's changed?

I have changed how phpLanguage parses step definition in context files. Behat allows to define arguments in the definition that will be passed as function parameters, [see Behat doc](https://docs.behat.org/en/latest/quick_start.html#defining-steps).

I have added a test file with various valid Behat definitions and there corresponding output after parsing.

I've tested my changes in vim. I can see that the lsp detects step definitions that contains argument, which it didn't before, see corresponding screenshots in annexes . The step suggestions are also working better but not perfectly, see corresponding screenshots in annexes


### ⚡️ What's your motivation? 

The current implementation only detects corresponding strings, that is, arguments (:arg) are not considered as variable but treated literally. That is, in my opinion, useless. Same goes for step suggestions.

### 🏷️ What kind of change is this?

- :zap: New feature (non-breaking change which adds new behaviour)

### ♻️ Anything particular you want feedback on?

LSP suggestions only detects step definitions on the first typed character. Adding a second one, the suggestions are gone, see corresponding screenshots.

### 📋 Checklist:

<!--- 
This is to help you remember all the little things we often forget to do!

Feel free to delete any tasks that are not relevant, or add new ones.
-->

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)
- [x] I've changed the behaviour of the code
  - [x] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [x] Users should know about my change
  - [ ] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request.

### Annexes
#### Diagnostics
Done with the same files

Before
![before_diagnostics](https://github.com/user-attachments/assets/69db1c5e-dea1-4054-90a9-61508cc6a3f7)

After
![after_diagnostics](https://github.com/user-attachments/assets/3df004e3-28f0-4853-96a3-edc5740974e9)

#### Suggestions

Before
![before_suggestions](https://github.com/user-attachments/assets/487cc33a-f187-45b1-ab1c-fd5b571e2d1a)

After
![after_suggestions](https://github.com/user-attachments/assets/78ead831-5c0e-4312-81a2-4b6376c95a6e)

Suggestions fails if more then one character is typed

One character typed
![one_char_suggestions](https://github.com/user-attachments/assets/55fe9d65-01a3-4a08-a3e0-64b05776c722)

Adding a second one 
![two_char_suggestions](https://github.com/user-attachments/assets/d27f34a3-0ff8-4488-8495-aa5b819bc386)


----

*This text was originally generated from a [template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates), then edited by hand. [You can modify the template here.](https://github.com/cucumber/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
