### PR TITLE
Syntax highlighting for comments (take 2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 ### Added
+- Syntax highlighting for comments (`#`) ([#245](https://github.com/cucumber/language-service/pull/245))
 - (Python) Support the pypi-parse step definition matcher used by behave and pytest-bdd ([#236](https://github.com/cucumber/language-service/pull/236))
 - Added behat arg detection ([#228](https://github.com/cucumber/language-service/pull/228))
 - Added support for Node versions 20, 22 and 23 ([#235](https://github.com/cucumber/language-service/pull/235))

--- a/src/service/getGherkinSemanticTokens.ts
+++ b/src/service/getGherkinSemanticTokens.ts
@@ -14,6 +14,7 @@ export const semanticTokenTypes: SemanticTokenTypes[] = [
   SemanticTokenTypes.type, // @tags and DocString ```type
   SemanticTokenTypes.variable, // step <placeholder>
   SemanticTokenTypes.property, // examples table header row
+  SemanticTokenTypes.comment, // # comments
 ]
 
 type Token = {
@@ -26,7 +27,7 @@ type TokenLines = Readonly<Array<Token[] | undefined>>
 
 const indexByType = Object.fromEntries(semanticTokenTypes.map((type, index) => [type, index]))
 
-// https://microsoft.github.io/language-server-protocol/specifications/specification-3-17/#textDocument_semanticTokens
+// https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_semanticTokens
 export function getGherkinSemanticTokens(
   gherkinSource: string,
   expressions: readonly Expression[]
@@ -172,6 +173,9 @@ export function getGherkinSemanticTokens(
       }
       inExamples = false
       return arr
+    },
+    comment(comment, arr) {
+      return makeLocationToken(comment.location, comment.text, SemanticTokenTypes.comment, arr)
     },
   })
 

--- a/test/service/getGherkinSemanticTokens.test.ts
+++ b/test/service/getGherkinSemanticTokens.test.ts
@@ -58,6 +58,7 @@ Feature: a
     ])
     const actual = tokenize(gherkinSource, semanticTokens.data)
     const expected: TokenWithType[] = [
+      ['# some comment', SemanticTokenTypes.comment],
       ['@foo', SemanticTokenTypes.type],
       ['@bar', SemanticTokenTypes.type],
       ['Feature', SemanticTokenTypes.keyword],


### PR DESCRIPTION
### 🤔 What's changed?

Comments now have syntax highlighting

Before

![before](https://github.com/user-attachments/assets/46cba88d-6bef-4183-9938-4c5eafd3d172)

After

![after](https://github.com/user-attachments/assets/378e7103-a335-4f1b-ba27-30f7c95205ff)

### ⚡️ What's your motivation? 

- Match other common language implementations of providing syntax highlighting for comments
- Match common syntax highlighting for gherkin (such as the [Cucumber docs](https://cucumber.io/)

### 🏷️ What kind of change is this?

<!--- Delete any options that are not relevant -->

- :zap: New feature (non-breaking change which adds new behaviour)

### ♻️ Anything particular you want feedback on?

<!-- 
Is there anything in this change you're unsure about, or would 
particularly like reviewers to give you feedback on?
-->

### 📋 Checklist:

<!--- 
This is to help you remember all the little things we often forget to do!

Feel free to delete any tasks that are not relevant, or add new ones.
-->

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://github.com/cucumber/.github/tree/main?tab=coc-ov-file)
- [x] I've changed the behaviour of the code
  - [x] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [x] Users should know about my change
  - [x] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request.
  
  ---
  
  Thanks to @kieran-ryan for #212 which this was based on. Since the merge of #220, this feature becomes a trivial change