### PR TITLE
fix: properly assign parameter:cucumber token in Scenario Outline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- Missing `parameter:cucumber` token for Scenario Outline ([#246](https://github.com/cucumber/language-service/issues/246))
+
 ## [1.7.0] - 2025-05-18
 ### Added
 - Syntax highlighting for comments (`#`) ([#245](https://github.com/cucumber/language-service/pull/245))

--- a/src/service/getGherkinSemanticTokens.ts
+++ b/src/service/getGherkinSemanticTokens.ts
@@ -114,26 +114,27 @@ export function getGherkinSemanticTokens(
           const character = startOfText + match.index
           arr = makeToken(line, character, match[0], SemanticTokenTypes.variable, arr)
         }
-      } else {
-        for (const expression of expressions) {
-          const args = expression.match(step.text)
-          if (args) {
-            for (const arg of args) {
-              if (arg.group.start) {
-                const character = step.location.column - 1 + step.keyword.length + arg.group.start
-                arr = makeToken(
-                  step.location.line - 1,
-                  character,
-                  arg.group.value,
-                  SemanticTokenTypes.parameter,
-                  arr
-                )
-              }
+      }
+
+      for (const expression of expressions) {
+        const args = expression.match(step.text)
+        if (args) {
+          for (const arg of args) {
+            if (arg.group.start) {
+              const character = step.location.column - 1 + step.keyword.length + arg.group.start
+              arr = makeToken(
+                step.location.line - 1,
+                character,
+                arg.group.value,
+                SemanticTokenTypes.parameter,
+                arr
+              )
             }
-            break
           }
+          break
         }
       }
+
       return arr
     },
     docString(docString, arr) {

--- a/test/service/getGherkinSemanticTokens.test.ts
+++ b/test/service/getGherkinSemanticTokens.test.ts
@@ -120,6 +120,47 @@ Feature: making drinks
     ]
     assert.deepStrictEqual(actual, expected)
   })
+
+  it('applies parameter token for scenario outline', () => {
+    const gherkinSource = `
+Feature: a
+  Scenario: a
+    Given I have "string" parameter
+
+  Scenario Outline: a
+    Given I have "string" parameter
+    And I have "<variable>" parameter
+
+    Examples:
+      | variable |
+      | value    |
+`
+
+    const parameterTypeRegistry = new ParameterTypeRegistry()
+    const cucumberExpression = new CucumberExpression(
+      'I have {string} parameter',
+      parameterTypeRegistry
+    )
+
+    const semanticTokens = getGherkinSemanticTokens(gherkinSource, [cucumberExpression])
+    const actual = tokenize(gherkinSource, semanticTokens.data)
+    const expected: TokenWithType[] = [
+      ['Feature', SemanticTokenTypes.keyword],
+      ['Scenario', SemanticTokenTypes.keyword],
+      ['Given ', SemanticTokenTypes.keyword],
+      ['"string"', SemanticTokenTypes.parameter],
+      ['Scenario Outline', SemanticTokenTypes.keyword],
+      ['Given ', SemanticTokenTypes.keyword],
+      ['"string"', SemanticTokenTypes.parameter],
+      ['And ', SemanticTokenTypes.keyword],
+      ['<variable>', SemanticTokenTypes.variable],
+      ['"<variable>"', SemanticTokenTypes.parameter],
+      ['Examples', SemanticTokenTypes.keyword],
+      ['variable', SemanticTokenTypes.property],
+      ['value', SemanticTokenTypes.string],
+    ]
+    assert.deepStrictEqual(actual, expected)
+  })
 })
 
 // See https://microsoft.github.io/language-server-protocol/specifications/specification-3-17/#textDocument_semanticTokens


### PR DESCRIPTION
Fixes #246


### 🤔 What's changed?

The token is now assigned unconditionally even within Scenario Outlines.

### 🏷️ What kind of change is this?

- :bug: Bug fix (non-breaking change which fixes a defect)
