### PR TITLE
Find Ruby step definitions when defined by a `step()` method

### DIFF
--- a/src/language/rubyLanguage.ts
+++ b/src/language/rubyLanguage.ts
@@ -76,7 +76,7 @@ export const rubyLanguage: Language = {
       (regex) @expression
     ]
   )
-  (#match? @method "(Given|When|Then|And|But)$")
+  (#match? @method "(Given|When|Then|And|But|step)$")
 ) @root
 `,
   ],


### PR DESCRIPTION
Turnip defines steps with the method `step`, it doesn't (currently) support Given/When/Then/etc. Also those method names aren't Ruby-like because they start with a capital letter, so even aliasing them doesn't _feel_ great, though it is a workaround.

It'd be lovely if the Cucumber language service could find these `step '...' do; end` definitions =)

<!---
Thanks for helping to make Cucumber better! 💖

You can feel free to open a "Draft" status pull request if you're not ready for feedback yet.

Don't worry about getting everything perfect! We're here to help and will coach you through
to getting your pull request ready to merge.

The prompts below are for guidance to help you describe your change in a way that is most 
likely to make sense to other people when they are reviewing it. Still, it's just a guide, 
so feel free to delete anything that doesn't feel appropriate, and add anything additional 
that seems like it would provide useful context. 👏🏻
-->

### 🤔 What's changed?

`step` has been added to the list of method names matched by the `defineStepDefinitionQueries` in the Ruby language.

### ⚡️ What's your motivation? 

<!-- 
What motivated you to propose this change? Does it fix a bug? Add a new feature?
If it fixes an open issue, you can link to the issue here, e.g. "Fixes #99"
-->

This allows the Cucumber LSP to find step definitions in a repo using https://github.com/jnicklas/turnip, e.g.
```rb
module FeatureSteps
  step "I am logged in" do
    login(@user)
  end
  # ...
end
```
<img width="589" height="123" alt="image" src="https://github.com/user-attachments/assets/2f668f62-abc3-4dd3-b41f-441def929490" />


### 🏷️ What kind of change is this?

<!--- Delete any options that are not relevant -->

- :zap: New feature (non-breaking change which adds new behaviour)

### ♻️ Anything particular you want feedback on?

<!-- 
Is there anything in this change you're unsure about, or would 
particularly like reviewers to give you feedback on?
-->

It'd be lovely if this expression could be passed in by configuration, so we can easily match our own definitions in our own usages ☺️ 

### 📋 Checklist:

<!--- 
This is to help you remember all the little things we often forget to do!

Feel free to delete any tasks that are not relevant, or add new ones.
-->

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://github.com/cucumber/.github/tree/main?tab=coc-ov-file)
- [x] I've changed the behaviour of the code
  - [ ] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [ ] Users should know about my change
  - [ ] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request.

Sorry, I just made this through GitHub's fork-and-edit. Is it worth adding to the tests, when it's an addition of a method name to a regexp? Also I'm not sure if this should be documented.

I'm happy to do all that if it's necessary; so far this is fixing just my own situation, I don't know how prevalent VS Code + Cucumber extension + Ruby repo + Turnip gem usage is, and therefore how important it is to document this.

Perhaps I could work on a refactor to get this pattern into configuration, if y'all would accept that? _That_ would definitely be important to document and test. Might be a bit of work to acquaint myself with the language-service repo _and_ the language-server repo, like which provides configuration and how it gets passed through, and how to provide the current pattern as a default from the vscode repo =)

Thanks in advance, <span title="I heard Spider-Man was there">snance</span>,
Henry
