### PR TITLE
Support Behat PHP attributes

### DIFF
--- a/src/language/phpLanguage.ts
+++ b/src/language/phpLanguage.ts
@@ -1,10 +1,14 @@
 import { unsupportedOperation } from './helpers.js'
-import { Language } from './types.js'
+import { Language, TreeSitterSyntaxNode } from './types.js'
 
 export const phpLanguage: Language = {
   toParameterTypeName: unsupportedOperation,
   toParameterTypeRegExps: unsupportedOperation,
   toStepDefinitionExpression(node) {
+    if (node.type === 'string' || node.type === 'encapsed_string') {
+      return behatifyStep(stringContent(node))
+    }
+
     // match multiline comment
     const text = node.text
     const match = text.match(/^(\/\*\*[\s*]*)([\s\S]*)(\n[\s]*\*\/)/)
@@ -19,6 +23,30 @@ export const phpLanguage: Language = {
   (comment)+ @expression
   (#match? @expression "@(Given|When|Then)")
 ) @root
+`,
+    `
+(
+  (method_declaration
+    attributes: (attribute_list
+      (attribute_group
+        (attribute
+          (name) @attribute-name
+          parameters: (arguments (argument [(string) (encapsed_string)] @expression)))))
+  ) @root
+  (#match? @attribute-name "^(Given|When|Then|Step)$")
+)
+`,
+    `
+(
+  (method_declaration
+    attributes: (attribute_list
+      (attribute_group
+        (attribute
+          (qualified_name (name) @attribute-name)
+          parameters: (arguments (argument [(string) (encapsed_string)] @expression)))))
+  ) @root
+  (#match? @attribute-name "^(Given|When|Then|Step)$")
+)
 `,
   ],
   snippetParameters: {
@@ -57,7 +85,19 @@ export function behatifyStep(step: string): RegExp {
 }
 
 function stripIdentifier(text: string): string {
-  return text.replace(/@(Given |When |Then )/, '').trim()
+  return text.replace(/@(Given |When |Then |Step )/, '').trim()
+}
+
+function stringContent(node: TreeSitterSyntaxNode): string {
+  const content = node.children
+    .filter((child) => child.type === 'string_content')
+    .map((child) => child.text)
+    .join('')
+  if (content) {
+    return content
+  }
+
+  return node.text.slice(1, -1)
 }
 
 function cleanRegExp(re: string): RegExp {

--- a/test/language/ExpressionBuilder.test.ts
+++ b/test/language/ExpressionBuilder.test.ts
@@ -110,6 +110,15 @@ Please register a ParameterType for 'undefined-parameter'`,
           }
         }
         assert(matched, 'The generated expressions did not match parameter type {date}')
+      } else if (languageName === 'php') {
+        assert.deepStrictEqual(expressions, [
+          /^a regexp$/,
+          /^I test this change$/,
+          /^I use a short attribute$/,
+          /^I use a fully qualified attribute$/,
+          /^I use a generic attribute$/,
+        ])
+        assert.deepStrictEqual(errors, ['There is already a parameter type with name int'])
       } else {
         assert.deepStrictEqual(expressions, [/^a regexp$/, /^I test this change$/])
         assert.deepStrictEqual(errors, ['There is already a parameter type with name int'])

--- a/test/language/testdata/php/StepDefinitions.php
+++ b/test/language/testdata/php/StepDefinitions.php
@@ -2,6 +2,9 @@
 
 namespace LanguageService;
 
+use Behat\Step\Given;
+use Behat\Step\Step;
+
 class StepDefinitions
 {
     /**
@@ -18,5 +21,23 @@ class StepDefinitions
     public function test_changes()
     {
         // Given
+    }
+
+    #[Given('^I use a short attribute$')]
+    public function short_attribute()
+    {
+        // Given
+    }
+
+    #[\Behat\Step\Then('^I use a fully qualified attribute$')]
+    public function fully_qualified_attribute()
+    {
+        // Then
+    }
+
+    #[Step('^I use a generic attribute$')]
+    public function generic_attribute()
+    {
+        // Step
     }
 }


### PR DESCRIPTION
## Summary
- recognize Behat PHP 8 attributes as PHP step definitions
- support short imported attributes and qualified attribute names
- cover generic #[Step] alongside Given/When/Then

Fixes #289.

## Testing
- npm test
- npm run eslint
- npm run build