### PR TITLE
feat: add Kotlin step definition support

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,7 +93,8 @@
     "tree-sitter-ruby": "0.23.1",
     "tree-sitter-rust": "0.23.1",
     "tree-sitter-scala": "^0.23.4",
-    "tree-sitter-typescript": "0.23.2"
+    "tree-sitter-typescript": "0.23.2",
+    "tree-sitter-kotlin": "^0.3.8"
   },
   "devDependencies": {
     "@cucumber/cucumber": "^13.0.0",

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -50,6 +50,11 @@ const languages = [
     dir: '',
     wasm: 'scala',
   },
+  {
+    npm: 'tree-sitter-kotlin',
+    dir: '',
+    wasm: 'kotlin',
+  },
 ]
 
 // Build wasm parsers for supported languages

--- a/src/language/kotlinLanguage.ts
+++ b/src/language/kotlinLanguage.ts
@@ -1,0 +1,88 @@
+import { Language, TreeSitterSyntaxNode } from './types.js'
+
+export const kotlinLanguage: Language = {
+  toParameterTypeName(node) {
+    switch (node.type) {
+      case 'string_literal': {
+        return stringLiteral(node)
+      }
+      case 'simple_identifier': {
+        return node.text
+      }
+      default: {
+        throw new Error(`Unsupported node type ${node.type}`)
+      }
+    }
+  },
+  toParameterTypeRegExps(node) {
+    return stringLiteral(node)
+  },
+  toStepDefinitionExpression(node) {
+    if (node.type === 'string_literal') {
+      const text = stringLiteral(node)
+      const hasRegExpAnchors = text[0] == '^' || text[text.length - 1] == '$'
+      return hasRegExpAnchors ? new RegExp(text) : text
+    }
+    throw new Error(`Unsupported node type ${node.type}`)
+  },
+
+  defineParameterTypeQueries: [
+    `
+(function_declaration
+  (modifiers
+    (annotation
+      (constructor_invocation
+        (user_type (type_identifier) @annotation-name)
+        (value_arguments (value_argument (string_literal) @expression))
+      )
+    )
+  )
+  (simple_identifier) @name
+  (#eq? @annotation-name "ParameterType")
+) @root
+`,
+  ],
+  defineStepDefinitionQueries: [
+    `
+(function_declaration
+  (modifiers
+    (annotation
+      (constructor_invocation
+        (user_type (type_identifier) @annotation-name)
+        (value_arguments (value_argument (string_literal) @expression))
+      )
+    )
+  )
+  (#match? @annotation-name "Given|When|Then|And|But")
+) @root
+`,
+  ],
+  snippetParameters: {
+    int: { type: 'Int', name: 'i' },
+    float: { type: 'Float', name: 'f' },
+    word: { type: 'String' },
+    string: { type: 'String', name: 's' },
+    double: { type: 'Double', name: 'd' },
+    bigdecimal: { type: 'java.math.BigDecimal', name: 'bigDecimal' },
+    byte: { type: 'Byte', name: 'b' },
+    short: { type: 'Short', name: 's' },
+    long: { type: 'Long', name: 'l' },
+    biginteger: { type: 'java.math.BigInteger', name: 'bigInteger' },
+    '': { type: 'Any', name: 'arg' },
+  },
+  defaultSnippetTemplate: `
+    @{{ keyword }}("{{ expression }}")
+    fun {{ #underscore }}{{ expression }}{{ /underscore }}({{ #parameters }}{{ #seenParameter }}, {{ /seenParameter }}{{ name }}: {{ type }}{{ /parameters }}) {
+        // {{ blurb }}
+    }
+`,
+}
+
+function stringLiteral(node: TreeSitterSyntaxNode | null): string {
+  if (node === null) throw new Error('node cannot be null')
+  const text = node.text
+  if (text.startsWith('"') && text.endsWith('"')) {
+    return text.slice(1, -1).replace(/\\\\/g, '\\')
+  }
+  return text
+}

--- a/src/language/languages.ts
+++ b/src/language/languages.ts
@@ -2,6 +2,7 @@ import { csharpLanguage } from './csharpLanguage.js'
 import { goLanguage } from './goLanguage.js'
 import { javaLanguage } from './javaLanguage.js'
 import { javascriptLanguage } from './javascriptLanguage.js'
+import { kotlinLanguage } from './kotlinLanguage.js'
 import { phpLanguage } from './phpLanguage.js'
 import { pythonLanguage } from './pythonLanguage.js'
 import { rubyLanguage } from './rubyLanguage.js'
@@ -21,6 +22,7 @@ const languageByName: Record<LanguageName, Language> = {
   javascript: javascriptLanguage,
   go: goLanguage,
   scala: scalaLanguage,
+  kotlin: kotlinLanguage,
 }
 
 export function getLanguage(languageName: LanguageName): Language {

--- a/src/language/types.ts
+++ b/src/language/types.ts
@@ -46,6 +46,7 @@ export const LanguageNames = [
   'javascript',
   'go',
   'scala',
+  'kotlin',
 ] as const
 export type LanguageName = (typeof LanguageNames)[number]
 

--- a/src/tree-sitter-node/NodeParserAdapter.ts
+++ b/src/tree-sitter-node/NodeParserAdapter.ts
@@ -7,6 +7,8 @@ import Go from 'tree-sitter-go'
 // @ts-ignore
 import Java from 'tree-sitter-java'
 // @ts-ignore
+import Kotlin from 'tree-sitter-kotlin'
+// @ts-ignore
 import Php from 'tree-sitter-php'
 // @ts-ignore
 import Python from 'tree-sitter-python'
@@ -57,6 +59,9 @@ export class NodeParserAdapter implements ParserAdapter {
         break
       case 'scala':
         this.parser.setLanguage(Scala)
+        break
+      case 'kotlin':
+        this.parser.setLanguage(Kotlin)
         break
       default:
         throw new Error(`Unsupported language: ${languageName}`)


### PR DESCRIPTION
## Summary

- Adds `kotlinLanguage` with tree-sitter queries for class-based step definitions (`@Given`/`@When`/`@Then`) and `@ParameterType` annotations, including expression-body functions (`= expr` syntax)
- Adds `'kotlin'` to `LanguageNames` and the language registry
- Adds Kotlin case to `NodeParserAdapter`
- Adds `tree-sitter-kotlin` to `optionalDependencies`
- Adds `kotlin` to `scripts/build.js` so `kotlin.wasm` is built by `prepare`

## Dependency chain

This PR is part of two, adding Kotlin support to the Cucumber Language Server:

1. **This PR** — `cucumber/language-service` — Kotlin parsing
2. `cucumber/language-server` (companion PR) — glue file discovery for `.kt`/`.kts`, wasmBasePath fix, null-settings crash fix

## Test plan

- [x] Build passes: `npm run build`
- [x] Kotlin step definitions (`@Given`, `@When`, `@Then`) are recognized
- [x] `@ParameterType` annotations are recognized
- [x] Expression-body functions (`fun step() = ...`) are recognized