### PR TITLE
Clojure support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+- Add Clojure support ([309](https://github.com/cucumber/language-service/pull/309))
+
 ### Added
 - Add Scala support ([#237](https://github.com/cucumber/language-service/issues/237))
 

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@
 - 🌎 Gherkin localisation
 - 📖 Language support
   - C#
+  - Clojure
   - Go
   - Java
   - JavaScript

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,6 @@
         "@cucumber/messages": "^33.0.0",
         "@types/js-search": "1.4.4",
         "@types/mustache": "4.2.6",
-        "@yogthos/tree-sitter-clojure": "*",
         "fuse.js": "7.5.0",
         "js-search": "2.0.1",
         "mustache": "4.2.0",
@@ -52,7 +51,7 @@
         "node": "18 || 20 || 22 || >=23"
       },
       "optionalDependencies": {
-        "@yogthos/tree-sitter-clojure": "^0.0.14",
+        "@yogthos/tree-sitter-clojure": "0.0.14",
         "tree-sitter": "^0.21.1",
         "tree-sitter-c-sharp": "0.23.1",
         "tree-sitter-cli": "0.24.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,11 +15,12 @@
         "@cucumber/messages": "^33.0.0",
         "@types/js-search": "1.4.4",
         "@types/mustache": "4.2.6",
+        "@yogthos/tree-sitter-clojure": "*",
         "fuse.js": "7.5.0",
         "js-search": "2.0.1",
         "mustache": "4.2.0",
         "vscode-languageserver-types": "3.18.0",
-        "web-tree-sitter": "^0.24.7"
+        "web-tree-sitter": "^0.24.6"
       },
       "devDependencies": {
         "@cucumber/cucumber": "^13.0.0",
@@ -51,6 +52,7 @@
         "node": "18 || 20 || 22 || >=23"
       },
       "optionalDependencies": {
+        "@yogthos/tree-sitter-clojure": "^0.0.14",
         "tree-sitter": "^0.21.1",
         "tree-sitter-c-sharp": "0.23.1",
         "tree-sitter-cli": "0.24.4",
@@ -1029,6 +1031,26 @@
       "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.2.0.tgz",
       "integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==",
       "dev": true
+    },
+    "node_modules/@yogthos/tree-sitter-clojure": {
+      "version": "0.0.14",
+      "resolved": "https://registry.npmjs.org/@yogthos/tree-sitter-clojure/-/tree-sitter-clojure-0.0.14.tgz",
+      "integrity": "sha512-t/FvXa0fbkKw4MJ5I+ohgC39jQmUT/LUeA1HWXWCasETEiNjJ7Hr9yPrhE/fuAkut7HpNRmWLfqePn204hnssw==",
+      "hasInstallScript": true,
+      "license": "SEE LICENSE IN COPYING.txt",
+      "optional": true,
+      "dependencies": {
+        "node-addon-api": "^8.3.1",
+        "node-gyp-build": "^4.8.4"
+      },
+      "peerDependencies": {
+        "tree-sitter": ">=0.22.0"
+      },
+      "peerDependenciesMeta": {
+        "tree-sitter": {
+          "optional": true
+        }
+      }
     },
     "node_modules/abbrev": {
       "version": "5.0.0",
@@ -4058,9 +4080,9 @@
       "dev": true
     },
     "node_modules/node-addon-api": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.3.0.tgz",
-      "integrity": "sha512-8VOpLHFrOQlAH+qA0ZzuGRlALRA6/LVh8QJldbrC4DY0hXoMP0l4Acq8TzFC018HztWiRqyCEj2aTWY2UvnJUg==",
+      "version": "8.9.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.9.0.tgz",
+      "integrity": "sha512-ekZMeaaIzSQTSpr7X2X3iJM7lTzgnx8ahAG9pJfT/7+14mlEM8ZYQ9cgCDvSSRbReFK0oHli3WrZdCiRsgAT9Q==",
       "license": "MIT",
       "optional": true,
       "engines": {

--- a/package.json
+++ b/package.json
@@ -80,9 +80,10 @@
     "js-search": "2.0.1",
     "mustache": "4.2.0",
     "vscode-languageserver-types": "3.18.0",
-    "web-tree-sitter": "^0.24.7"
+    "web-tree-sitter": "^0.24.6"
   },
   "optionalDependencies": {
+    "@yogthos/tree-sitter-clojure": "0.0.14",
     "tree-sitter": "^0.21.1",
     "tree-sitter-c-sharp": "0.23.1",
     "tree-sitter-cli": "0.24.4",

--- a/package.json
+++ b/package.json
@@ -124,5 +124,10 @@
   },
   "peerDependencies": {
     "web-tree-sitter": "^0.24.6"
+  },
+  "overrides": {
+    "@yogthos/tree-sitter-clojure": {
+      "tree-sitter": "$tree-sitter"
+    }
   }
 }

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "prepublishOnly": "npm run build",
     "eslint-fix": "eslint --ext ts --max-warnings 0 --fix src test",
     "eslint": "eslint --ext ts --max-warnings 0 src test",
-    "prepare": "husky && node scripts/build.js && cp node_modules/web-tree-sitter/tree-sitter.wasm dist"
+    "prepare": "husky && node scripts/build.js && cp node_modules/web-tree-sitter/tree-sitter.wasm dist && cd node_modules/@yogthos/tree-sitter-clojure && npx node-gyp rebuild"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "prepublishOnly": "npm run build",
     "eslint-fix": "eslint --ext ts --max-warnings 0 --fix src test",
     "eslint": "eslint --ext ts --max-warnings 0 src test",
-    "prepare": "husky && node scripts/build.js && cp node_modules/web-tree-sitter/tree-sitter.wasm dist && cd node_modules/@yogthos/tree-sitter-clojure && npx node-gyp rebuild"
+    "prepare": "husky && node scripts/build.js && cp node_modules/web-tree-sitter/tree-sitter.wasm dist"
   },
   "repository": {
     "type": "git",

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -21,6 +21,11 @@ const languages = [
     wasm: 'c_sharp',
   },
   {
+    npm: '@yogthos/tree-sitter-clojure',
+    dir: '',
+    wasm: 'clojure',
+  },
+  {
     npm: 'tree-sitter-php',
     dir: 'php',
     wasm: 'php',

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -85,6 +85,9 @@ if (!fs.existsSync(treeSitterCli)) {
       console.log(`Regenerating parser for ${npm}`)
       try {
         execSync(`${treeSitterCliAbsolute} generate`, { cwd: generateDir, stdio: 'inherit' })
+        // Rebuild native binding with the regenerated parser
+        console.log(`Rebuilding native binding for ${npm}`)
+        execSync('npx node-gyp rebuild', { cwd: generateDir, stdio: 'inherit' })
       } catch (err) {
         console.error(`Failed to regenerate parser for ${npm}: ${err.message}`)
         process.exit(1)

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-import { exec } from 'child_process'
+import { exec, execSync } from 'child_process'
 import fs from 'fs'
 import path from 'path'
 
@@ -24,6 +24,8 @@ const languages = [
     npm: '@yogthos/tree-sitter-clojure',
     dir: '',
     wasm: 'clojure',
+    // Regenerate parser to ensure ABI compatibility with tree-sitter@0.21.x
+    generate: true,
   },
   {
     npm: 'tree-sitter-php',
@@ -66,7 +68,7 @@ const treeSitterCli = path.join('node_modules', '.bin', 'tree-sitter')
 if (!fs.existsSync(treeSitterCli)) {
   console.info(`Skipping compilation of tree-sitter wasms - ${treeSitterCli} is not installed`)
 } else {
-  for (const { npm, dir, wasm } of languages) {
+  for (const { npm, dir, wasm, generate } of languages) {
     const module = path.join('node_modules', npm, dir)
 
     if (!fs.existsSync(module)) {
@@ -74,6 +76,19 @@ if (!fs.existsSync(treeSitterCli)) {
         `Module ${module} does not exist. This is likely due to an installation and/or build failure of the module. Please check the logs.`
       )
       process.exit(1)
+    }
+
+    // Regenerate parser.c to ensure ABI compatibility with tree-sitter-cli version
+    if (generate) {
+      const generateDir = path.join('node_modules', npm)
+      const treeSitterCliAbsolute = path.resolve(treeSitterCli)
+      console.log(`Regenerating parser for ${npm}`)
+      try {
+        execSync(`${treeSitterCliAbsolute} generate`, { cwd: generateDir, stdio: 'inherit' })
+      } catch (err) {
+        console.error(`Failed to regenerate parser for ${npm}: ${err.message}`)
+        process.exit(1)
+      }
     }
 
     let command

--- a/src/language/clojureLanguage.ts
+++ b/src/language/clojureLanguage.ts
@@ -1,7 +1,7 @@
 import { StringOrRegExp } from '@cucumber/cucumber-expressions'
 
-import { childrenToString, unsupportedOperation } from './helpers.js'
-import { Language, NodePredicate, TreeSitterSyntaxNode } from './types.js'
+import { unsupportedOperation } from './helpers.js'
+import { Language, TreeSitterSyntaxNode } from './types.js'
 
 export const clojureLanguage: Language = {
   toParameterTypeName: unsupportedOperation,
@@ -13,7 +13,14 @@ export const clojureLanguage: Language = {
         return new RegExp(text)
       }
       case 'str_lit': {
-        return stringLiteral(node)
+        const text = stringLiteral(node)
+        // If the string contains regex anchors or capture groups, treat as regex
+        const hasRegExpAnchors = text[0] == '^' || text[text.length - 1] == '$'
+        const hasCaptures = /\(.*\)/.test(text)
+        if (hasRegExpAnchors || hasCaptures) {
+          return new RegExp(text)
+        }
+        return text
       }
       default:
         throw new Error(`Unsupported node type: ${node.type}`)
@@ -54,10 +61,13 @@ export const clojureLanguage: Language = {
 `,
 }
 
-const NO_QUOTES: NodePredicate = (child) => child.type !== '"'
-
 export function stringLiteral(node: TreeSitterSyntaxNode): string {
-  return childrenToString(node, NO_QUOTES)
+  // str_lit text is like "expression" — strip the surrounding quotes
+  const text = node.text
+  if (text.startsWith('"') && text.endsWith('"')) {
+    return text.slice(1, -1)
+  }
+  return text
 }
 
 export function regexLiteral(node: TreeSitterSyntaxNode): string {

--- a/src/language/clojureLanguage.ts
+++ b/src/language/clojureLanguage.ts
@@ -1,0 +1,70 @@
+import { StringOrRegExp } from '@cucumber/cucumber-expressions'
+
+import { childrenToString, unsupportedOperation } from './helpers.js'
+import { Language, NodePredicate, TreeSitterSyntaxNode } from './types.js'
+
+export const clojureLanguage: Language = {
+  toParameterTypeName: unsupportedOperation,
+  toParameterTypeRegExps: unsupportedOperation,
+  toStepDefinitionExpression(node: TreeSitterSyntaxNode): StringOrRegExp {
+    switch (node.type) {
+      case 'regex_lit': {
+        const text = regexLiteral(node)
+        return new RegExp(text)
+      }
+      case 'str_lit': {
+        return stringLiteral(node)
+      }
+      default:
+        throw new Error(`Unsupported node type: ${node.type}`)
+    }
+  },
+  // Clojure cucumber does not support ParameterType definitions
+  defineParameterTypeQueries: [],
+  defineStepDefinitionQueries: [
+    `
+(list_lit
+  value: (sym_lit
+    name: (sym_name) @annotation-name)
+  value: [
+    (str_lit) @expression
+    (regex_lit) @expression
+  ]
+  (#match? @annotation-name "^(Given|When|Then|And|But)$")
+) @root
+`,
+  ],
+  snippetParameters: {
+    int: { type: 'int', name: 'i' },
+    float: { type: 'float', name: 'f' },
+    word: { type: 'String' },
+    string: { type: 'String', name: 's' },
+    double: { type: 'double', name: 'd' },
+    bigdecimal: { type: 'BigDecimal', name: 'bigDecimal' },
+    byte: { type: 'byte', name: 'b' },
+    short: { type: 'short', name: 's' },
+    long: { type: 'long', name: 'l' },
+    biginteger: { type: 'BigInteger', name: 'bigInteger' },
+    '': { type: 'Object', name: 'arg' },
+  },
+  defaultSnippetTemplate: `
+({{ keyword }} "{{ expression }}" [{{ #parameters }}{{ #seenParameter }} {{ /seenParameter }}{{ name }}{{ /parameters }}]
+  ;; {{ blurb }}
+  )
+`,
+}
+
+const NO_QUOTES: NodePredicate = (child) => child.type !== '"'
+
+export function stringLiteral(node: TreeSitterSyntaxNode): string {
+  return childrenToString(node, NO_QUOTES)
+}
+
+export function regexLiteral(node: TreeSitterSyntaxNode): string {
+  // regex_lit text is like #"^pattern$" — strip the #" prefix and " suffix
+  const text = node.text
+  if (text.startsWith('#"') && text.endsWith('"')) {
+    return text.slice(2, -1)
+  }
+  return text
+}

--- a/src/language/languages.ts
+++ b/src/language/languages.ts
@@ -1,3 +1,4 @@
+import { clojureLanguage } from './clojureLanguage.js'
 import { csharpLanguage } from './csharpLanguage.js'
 import { goLanguage } from './goLanguage.js'
 import { javaLanguage } from './javaLanguage.js'
@@ -14,6 +15,7 @@ const languageByName: Record<LanguageName, Language> = {
   java: javaLanguage,
   tsx: tsxLanguage,
   c_sharp: csharpLanguage,
+  clojure: clojureLanguage,
   php: phpLanguage,
   ruby: rubyLanguage,
   rust: rustLanguage,

--- a/src/language/types.ts
+++ b/src/language/types.ts
@@ -39,6 +39,7 @@ export const LanguageNames = [
   'java',
   'tsx',
   'c_sharp',
+  'clojure',
   'php',
   'python',
   'ruby',

--- a/src/tree-sitter-node/NodeParserAdapter.ts
+++ b/src/tree-sitter-node/NodeParserAdapter.ts
@@ -20,6 +20,7 @@ import Scala from 'tree-sitter-scala'
 import TypeScript from 'tree-sitter-typescript'
 
 import { LanguageName, ParserAdapter } from '../language/types.js'
+import Clojure from './clojureParser.js'
 
 export class NodeParserAdapter implements ParserAdapter {
   readonly parser = new Parser()
@@ -39,6 +40,10 @@ export class NodeParserAdapter implements ParserAdapter {
         break
       case 'c_sharp':
         this.parser.setLanguage(Csharp)
+        break
+      case 'clojure':
+        if (!Clojure) throw new Error('tree-sitter-clojure is not installed')
+        this.parser.setLanguage(Clojure)
         break
       case 'php':
         this.parser.setLanguage(Php.php)

--- a/src/tree-sitter-node/clojureParser.ts
+++ b/src/tree-sitter-node/clojureParser.ts
@@ -1,0 +1,27 @@
+import { readFileSync } from 'fs'
+import { createRequire } from 'module'
+import { dirname, resolve } from 'path'
+
+// Load tree-sitter-clojure via node-gyp-build since its index.js uses ESM top-level await
+// which is incompatible with this project's tree-sitter@0.21.1
+function loadClojure() {
+  try {
+    const req = createRequire(resolve(process.cwd(), '__placeholder.js'))
+    const pkgPath = req.resolve('@yogthos/tree-sitter-clojure/package.json')
+    const root = dirname(pkgPath)
+    const binding = req('node-gyp-build')(root)
+    binding.name = 'clojure'
+    try {
+      binding.nodeTypeInfo = JSON.parse(
+        readFileSync(resolve(root, 'src', 'node-types.json'), 'utf8')
+      )
+    } catch (_) {
+      // nodeTypeInfo is optional
+    }
+    return binding
+  } catch (_) {
+    return undefined
+  }
+}
+
+export default loadClojure()

--- a/test/language/ExpressionBuilder.test.ts
+++ b/test/language/ExpressionBuilder.test.ts
@@ -111,7 +111,12 @@ Please register a ParameterType for 'undefined-parameter'`,
         }
         assert(matched, 'The generated expressions did not match parameter type {date}')
       } else {
-        assert.deepStrictEqual(expressions, [/^a regexp$/, /^I test this change$/])
+        assert.deepStrictEqual(
+          expressions,
+          languageName === 'clojure'
+            ? [/^a regexp$/, /^I test this change$/, /^something happened$/, /^another thing$/]
+            : [/^a regexp$/, /^I test this change$/]
+        )
         assert.deepStrictEqual(errors, ['There is already a parameter type with name int'])
       }
     })

--- a/test/language/testdata/clojure/StepDefinitions.clj
+++ b/test/language/testdata/clojure/StepDefinitions.clj
@@ -1,0 +1,11 @@
+(Given #"^a regexp$" []
+  (println "done"))
+
+(When #"^I test this change$" []
+  (println "changed"))
+
+(Then #"^something happened$" []
+  (println "verified"))
+
+(And #"^another thing$" []
+  (println "also"))


### PR DESCRIPTION
<!---
Thanks for helping to make Cucumber better! 💖

You can feel free to open a "Draft" status pull request if you're not ready for feedback yet.

Don't worry about getting everything perfect! We're here to help and will coach you through
to getting your pull request ready to merge.

The prompts below are for guidance to help you describe your change in a way that is most 
likely to make sense to other people when they are reviewing it. Still, it's just a guide, 
so feel free to delete anything that doesn't feel appropriate, and add anything additional 
that seems like it would provide useful context. 👏🏻
-->

### 🤔 What's changed?

Added support for the Clojure language.

### ⚡️ What's your motivation? 

Currently, the Cucumber plugin in Vscode does not recognise step definitions written in clojure.  This is the first step. 

 - Add Clojure language support (src/language/clojureLanguage.ts)
    - Step definition detection via tree-sitter queries (Given, When, Then, And, But)
    - Handles both cucumber expressions ("I am user {string}") and regex patterns (#"^a regexp$")
    - Strings containing regex capture groups are automatically treated as regular expressions
    - Snippet generation for step definitions
  
  - Add 'clojure' to LanguageNames in src/language/types.ts
  - Register Clojure in src/language/languages.ts
  - Add @yogthos/tree-sitter-clojure as optional dependency for parsing
  - Add Clojure parser loading in src/tree-sitter-node/clojureParser.ts
  - Add Clojure to NodeParserAdapter and wasm build script
  - Add test data (test/language/testdata/clojure/StepDefinitions.clj)
  - Update README.md to list Clojure as a supported language
  
  Companion PRs needed:
  
  - cucumber/language-server — add .clj/.cljc/.cljs to glue file extensions
  - cucumber/vscode — add clojure to document selector and default glue patterns

### 🏷️ What kind of change is this?

- :zap: New feature (non-breaking change which adds new behaviour)

### 📋 Checklist:

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://github.com/cucumber/.github/tree/main?tab=coc-ov-file)
- [x] I've changed the behaviour of the code
  - [x] I have added/updated tests to cover my changes.
- [x] My change requires a change to the documentation.
  - [x] I have updated the documentation accordingly.
- [x] Users should know about my change
  - [x] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request.
