### PR TITLE
Capture the function as @root in the Rust step definition query

### DIFF
--- a/src/language/helpers.ts
+++ b/src/language/helpers.ts
@@ -1,5 +1,5 @@
 import { ParameterType, RegExps } from '@cucumber/cucumber-expressions'
-import { DocumentUri, LocationLink, Range } from 'vscode-languageserver-types'
+import { DocumentUri, LocationLink, Position, Range } from 'vscode-languageserver-types'
 
 import { Link, NodePredicate, TreeSitterQueryMatch, TreeSitterSyntaxNode } from './types'
 
@@ -31,17 +31,23 @@ export function createLocationLink(
   selectionNode: TreeSitterSyntaxNode,
   targetUri: DocumentUri
 ) {
-  const targetRange: Range = Range.create(
-    rootNode.startPosition.row,
-    rootNode.startPosition.column,
-    rootNode.endPosition.row,
-    rootNode.endPosition.column
-  )
   const targetSelectionRange: Range = Range.create(
     selectionNode.startPosition.row,
     selectionNode.startPosition.column,
     selectionNode.endPosition.row,
     selectionNode.endPosition.column
+  )
+  // The selection may precede the root node (a Rust attribute precedes its fn),
+  // and LSP requires the selection range to be contained in the target range.
+  const rootRange: Range = Range.create(
+    rootNode.startPosition.row,
+    rootNode.startPosition.column,
+    rootNode.endPosition.row,
+    rootNode.endPosition.column
+  )
+  const targetRange: Range = Range.create(
+    min(rootRange.start, targetSelectionRange.start),
+    max(rootRange.end, targetSelectionRange.end)
   )
   const locationLink: LocationLink = {
     targetRange,
@@ -49,6 +55,14 @@ export function createLocationLink(
     targetUri,
   }
   return locationLink
+}
+
+function min(a: Position, b: Position): Position {
+  return a.line < b.line || (a.line === b.line && a.character < b.character) ? a : b
+}
+
+function max(a: Position, b: Position): Position {
+  return a.line > b.line || (a.line === b.line && a.character > b.character) ? a : b
 }
 
 export function childrenToString(node: TreeSitterSyntaxNode, stringNodes: NodePredicate) {

--- a/src/language/rustLanguage.ts
+++ b/src/language/rustLanguage.ts
@@ -54,25 +54,26 @@ export const rustLanguage: Language = {
     `,
   ],
   defineStepDefinitionQueries: [
-    `(source_file 
-      (attribute_item 
-        (attribute 
-          (
-            (identifier) @meta-name 
-            arguments: (token_tree
-              [
-                (string_literal) @expression
-                (identifier)
-                (string_literal) @expression
-                (raw_string_literal) @expression
-              ]
-            )
+    `(
+      (attribute_item
+        (attribute
+          [(identifier) (scoped_identifier)] @meta-name
+          arguments: (token_tree
+            [
+              (string_literal) @expression
+              (identifier)
+              (string_literal) @expression
+              (raw_string_literal) @expression
+            ]
           )
-        )  
+        )
         (#match? @meta-name "given|when|then")
       )
-      (function_item) ) @root
-    `,
+      .
+      [(attribute_item) (line_comment) (block_comment)]*
+      .
+      (function_item) @root
+    )`,
   ],
   snippetParameters: {
     int: { type: 'i32', name: 'i' },

--- a/test/language/ExpressionBuilder.test.ts
+++ b/test/language/ExpressionBuilder.test.ts
@@ -89,6 +89,7 @@ function defineContract(makeParserAdapter: () => ParserAdapter) {
           /^a regexp$/,
           "the bee's knees",
           ...(languageName === 'javascript' ? ['a compiled format'] : []),
+          ...(languageName === 'rust' ? ['a stacked step'] : []),
         ])
         assert.deepStrictEqual(errors, [
           'There is already a parameter type with name int',

--- a/test/language/ExpressionBuilder.test.ts
+++ b/test/language/ExpressionBuilder.test.ts
@@ -68,11 +68,13 @@ function defineContract(makeParserAdapter: () => ParserAdapter) {
       for (const link of result.expressionLinks.map((l) => l.locationLink)) {
         assert(
           link.targetSelectionRange.start.line > link.targetRange.start.line ||
-            link.targetSelectionRange.start.character >= link.targetRange.start.character
+            (link.targetSelectionRange.start.line === link.targetRange.start.line &&
+              link.targetSelectionRange.start.character >= link.targetRange.start.character)
         )
         assert(
           link.targetSelectionRange.end.line < link.targetRange.end.line ||
-            link.targetSelectionRange.end.character <= link.targetRange.end.character
+            (link.targetSelectionRange.end.line === link.targetRange.end.line &&
+              link.targetSelectionRange.end.character <= link.targetRange.end.character)
         )
       }
       const expressions = result.expressionLinks.map(({ expression }) =>

--- a/test/language/testdata/rust/StepDefinitions.rs
+++ b/test/language/testdata/rust/StepDefinitions.rs
@@ -10,14 +10,18 @@ fn a_uuid(world: &mut StepDefinitions, uuid: String) {}
 #[given(expr = "a {date}")]
 fn a_date(world: &mut StepDefinitions,date: chrono::DateTime) {}
 
-#[given("a {planet}")]
-fn a_date(world: &mut StepDefinitions,date: chrono::DateTime) {}
+mod nested {
+    #[given("a {planet}")]
+    fn a_date(world: &mut StepDefinitions,date: chrono::DateTime) {}
+}
 
-#[given(regex = r"^a regexp$")]
+#[cucumber::given(regex = r"^a regexp$")]
 fn a_regexp(world: &mut StepDefinitions) {}
 
 #[given(expr = "an {undefined-parameter}")]
 fn an_undefined_parameter(world: &mut StepDefinitions, date: chrono::DateTime) {}
 
 #[given("the bee's knees")]
+/// A doc comment between the attribute and the fn
+#[when("a stacked step")]
 fn the_bees_knees(world: &mut StepDefinitions) {}


### PR DESCRIPTION
Closes #315

The Rust query now captures the `function_item` as `@root` and anchors it to the step attribute above it, with any further attributes or comments allowed in between. The `source_file` wrapper is gone, so step definitions inside `mod` blocks are found, and `[(identifier) (scoped_identifier)]` accepts `#[cucumber::given(…)]`.

In Rust the attribute is a sibling of the function in the syntax tree, not a child as in Java or C#, so `@root` cannot cover both and `targetSelectionRange` starts before `targetRange`. `createLocationLink` now takes the union of the two for `targetRange`. For every other language the selection is already inside the root and nothing changes. The containment assertion in `ExpressionBuilder.test.ts` would not have caught this: when the selection starts on an earlier line than the target it fell through to a character-only compare, which passes for a literal indented past `fn`. It now checks line and character together.

The Rust fixture exercises the new forms: one step in a `mod` block, one with a scoped path, one with a doc comment between attribute and function, and one with stacked `#[given]`/`#[when]` attributes. The stacked case adds `'a stacked step'` to the expected expressions for Rust, following the existing per-language exception for JavaScript.

Two commits: the query, then the range union with the tightened assertion.